### PR TITLE
Centralize authored road data helpers

### DIFF
--- a/src/client/AuthoredRoadVisual.client.lua
+++ b/src/client/AuthoredRoadVisual.client.lua
@@ -2,23 +2,24 @@ local AssetService = game:GetService("AssetService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Workspace = game:GetService("Workspace")
 
-local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local Config = require(Shared:WaitForChild("Config"))
+local RoadSampling = require(Shared:WaitForChild("RoadSampling"))
+local RoadSplineData = require(Shared:WaitForChild("RoadSplineData"))
 
 if Config.useAuthoredRoadEditorWorld ~= true then
 	return
 end
 
-local ROAD_EDITOR_ROOT_NAME = "Cab87RoadEditor"
-local ROAD_EDITOR_SPLINES_NAME = "Splines"
-local ROAD_EDITOR_POINTS_NAME = "RoadPoints"
-local ROAD_WIDTH_ATTR = "RoadWidth"
+local ROAD_EDITOR_ROOT_NAME = RoadSplineData.EDITOR_ROOT_NAME
+local ROAD_EDITOR_SPLINES_NAME = RoadSplineData.SPLINES_NAME
+local ROAD_EDITOR_POINTS_NAME = RoadSplineData.POINTS_NAME
+local ROAD_WIDTH_ATTR = RoadSplineData.ROAD_WIDTH_ATTR
 local RUNTIME_WORLD_NAME = "Cab87World"
-local RUNTIME_SPLINE_DATA_NAME = "AuthoredRoadSplineData"
+local RUNTIME_SPLINE_DATA_NAME = RoadSplineData.RUNTIME_DATA_NAME
 local CLIENT_VISUALS_NAME = "AuthoredRoadClientVisuals"
 
-local DEFAULT_AUTHORED_ROAD_WIDTH = 28
-local AUTHORED_ROAD_MIN_WIDTH = 8
-local AUTHORED_ROAD_MAX_WIDTH = 200
+local DEFAULT_AUTHORED_ROAD_WIDTH = RoadSampling.DEFAULT_ROAD_WIDTH
 local ROAD_MESH_THICKNESS = 1.2
 local ENDPOINT_WELD_DISTANCE = 22
 local INTERSECTION_RADIUS_SCALE = 0.5
@@ -93,141 +94,14 @@ local function hideEditorDebugGeometry()
 	end
 end
 
-local function sortedChildren(parent, className)
-	local children = {}
-	if not parent then
-		return children
-	end
-
-	for _, child in ipairs(parent:GetChildren()) do
-		if not className or child:IsA(className) then
-			table.insert(children, child)
-		end
-	end
-
-	table.sort(children, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return children
-end
-
-local function sanitizeRoadWidth(value)
-	local width = tonumber(value) or DEFAULT_AUTHORED_ROAD_WIDTH
-	return math.clamp(width, AUTHORED_ROAD_MIN_WIDTH, AUTHORED_ROAD_MAX_WIDTH)
-end
-
-local function getSplineRoadWidth(spline)
-	local configuredDefault = tonumber(Config.authoredRoadCollisionWidth) or DEFAULT_AUTHORED_ROAD_WIDTH
-	return sanitizeRoadWidth(tonumber(spline and spline:GetAttribute(ROAD_WIDTH_ATTR)) or configuredDefault)
-end
-
-local function getAuthoredSplines(root)
-	local splinesFolder = root and root:FindFirstChild(ROAD_EDITOR_SPLINES_NAME)
-	if splinesFolder and splinesFolder:IsA("Folder") then
-		return sortedChildren(splinesFolder, "Model")
-	end
-
-	local legacyPoints = root and root:FindFirstChild(ROAD_EDITOR_POINTS_NAME)
-	if legacyPoints and legacyPoints:IsA("Folder") then
-		return { root }
-	end
-
-	return {}
-end
-
-local function getAuthoredSplinePoints(spline)
-	local pointsFolder = spline and spline:FindFirstChild(ROAD_EDITOR_POINTS_NAME)
-	if not (pointsFolder and pointsFolder:IsA("Folder")) then
-		return {}
-	end
-
-	local points = {}
-	for _, child in ipairs(pointsFolder:GetChildren()) do
-		if child:IsA("BasePart") or child:IsA("Vector3Value") then
-			table.insert(points, child)
-		end
-	end
-
-	table.sort(points, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return points
-end
-
-local function getPointPosition(point)
-	if point:IsA("BasePart") then
-		return point.Position
-	end
-	return point.Value
-end
-
-local function catmullRom(p0, p1, p2, p3, t)
-	local t2 = t * t
-	local t3 = t2 * t
-	return 0.5 * ((2 * p1) + (-p0 + p2) * t + (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 + (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
-end
-
-local function sampleAuthoredSpline(points, closedCurve)
-	local positions = {}
-	for _, point in ipairs(points) do
-		table.insert(positions, getPointPosition(point))
-	end
-
-	if #positions < 2 then
-		return positions
-	end
-
-	if closedCurve and #positions < 3 then
-		closedCurve = false
-	end
-
-	local samples = {}
-	local sampleStep = math.max(Config.authoredRoadSampleStepStuds, 1)
-	if closedCurve then
-		local count = #positions
-		for i = 1, count do
-			local p0 = positions[((i - 2) % count) + 1]
-			local p1 = positions[i]
-			local p2 = positions[(i % count) + 1]
-			local p3 = positions[((i + 1) % count) + 1]
-			local segmentLen = (p2 - p1).Magnitude
-			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
-
-			for s = 0, subdivisions - 1 do
-				table.insert(samples, catmullRom(p0, p1, p2, p3, s / subdivisions))
-			end
-		end
-
-		if #samples > 1 then
-			table.insert(samples, samples[1])
-		end
-	else
-		for i = 1, #positions - 1 do
-			local p0 = positions[math.max(1, i - 1)]
-			local p1 = positions[i]
-			local p2 = positions[i + 1]
-			local p3 = positions[math.min(#positions, i + 2)]
-			local segmentLen = (p2 - p1).Magnitude
-			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
-
-			for s = 0, subdivisions - 1 do
-				table.insert(samples, catmullRom(p0, p1, p2, p3, s / subdivisions))
-			end
-		end
-
-		table.insert(samples, positions[#positions])
-	end
-
-	return samples
-end
-
-local function distanceXZ(a, b)
-	local dx = a.X - b.X
-	local dz = a.Z - b.Z
-	return math.sqrt(dx * dx + dz * dz)
-end
+local sanitizeRoadWidth = RoadSampling.sanitizeRoadWidth
+local distanceXZ = RoadSampling.distanceXZ
+local horizontalUnit = RoadSampling.horizontalUnit
+local catmullRom = RoadSampling.catmullRom
+local sampleLoopIsClosed = RoadSampling.sampleLoopIsClosed
+local getRoadSampleTangent = RoadSampling.getRoadSampleTangent
+local polylineLength = RoadSampling.polylineLength
+local samplePolylineAtFraction = RoadSampling.samplePolylineAtFraction
 
 local function heightConnectTolerance(widthA, widthB)
 	local width = math.min(sanitizeRoadWidth(widthA), sanitizeRoadWidth(widthB))
@@ -243,30 +117,10 @@ local function positionsConnectIn3D(a, b, widthA, widthB)
 end
 
 local function collectSplineBuildData(root)
-	local chains = {}
-	for _, spline in ipairs(getAuthoredSplines(root)) do
-		local points = getAuthoredSplinePoints(spline)
-		if #points >= 2 then
-			local closed = spline:GetAttribute("ClosedCurve") == true
-			local samples
-			if spline:GetAttribute("SampledRoadChain") == true then
-				samples = {}
-				for _, point in ipairs(points) do
-					table.insert(samples, getPointPosition(point))
-				end
-			else
-				samples = sampleAuthoredSpline(points, closed)
-			end
-				table.insert(chains, {
-					name = spline.Name,
-					samples = samples,
-					closed = closed,
-					width = getSplineRoadWidth(spline),
-					componentId = tonumber(spline:GetAttribute("ComponentId")) or 1,
-				})
-		end
-	end
-	return chains
+	return RoadSplineData.collectSampledChains(root, {
+		defaultRoadWidth = RoadSampling.getConfiguredRoadWidth(Config),
+		sampleStep = Config.authoredRoadSampleStepStuds,
+	})
 end
 
 local function getChainName(chain, fallback)
@@ -274,23 +128,9 @@ local function getChainName(chain, fallback)
 end
 
 local function collectProcessedJunctions(root)
-	local junctionsFolder = root and root:FindFirstChild("Junctions")
-	if not (junctionsFolder and junctionsFolder:IsA("Folder")) then
-		return {}
-	end
-
-	local junctions = {}
-	local children = sortedChildren(junctionsFolder, "Vector3Value")
-	for _, junctionData in ipairs(children) do
-		table.insert(junctions, {
-			center = junctionData.Value,
-			radius = tonumber(junctionData:GetAttribute("Radius")) or DEFAULT_AUTHORED_ROAD_WIDTH * INTERSECTION_RADIUS_SCALE,
-			componentId = tonumber(junctionData:GetAttribute("ComponentId")) or 1,
-			members = {},
-			chains = {},
-		})
-	end
-	return junctions
+	return RoadSplineData.collectJunctions(root, {
+		defaultRadius = DEFAULT_AUTHORED_ROAD_WIDTH * INTERSECTION_RADIUS_SCALE,
+	})
 end
 
 local function buildProcessedComponents(chains, junctions)
@@ -562,27 +402,12 @@ local function applyJunctionsToChains(chains, junctions)
 	end
 end
 
-local function sampleLoopIsClosed(samples)
-	if #samples < 3 then
-		return false
-	end
-	return distanceXZ(samples[1], samples[#samples]) <= 0.05 and math.abs(samples[1].Y - samples[#samples].Y) <= 0.05
-end
-
 local function roadRightFromTangent(tangent)
 	local right = Vector3.yAxis:Cross(tangent)
 	if right.Magnitude < 1e-4 then
 		return Vector3.xAxis
 	end
 	return right.Unit
-end
-
-local function horizontalUnit(vector)
-	local flat = Vector3.new(vector.X, 0, vector.Z)
-	if flat.Magnitude < 1e-4 then
-		return nil
-	end
-	return flat.Unit
 end
 
 local function lineIntersectionXZ(a, dirA, b, dirB)
@@ -980,99 +805,6 @@ end
 local function addMeshTriangle(state, a, b, c)
 	state.mesh:AddTriangle(a, b, c)
 	state.faces += 1
-end
-
-local function getRoadSampleTangent(samples, index, edgeCount, closedLoop, fallbackDir)
-	if closedLoop then
-		local prevIndex = index - 1
-		if prevIndex < 1 then
-			prevIndex = edgeCount
-		end
-		local nextIndex = index + 1
-		if nextIndex > edgeCount then
-			nextIndex = 1
-		end
-		local prevDir = horizontalUnit(samples[index] - samples[prevIndex])
-		local nextDir = horizontalUnit(samples[nextIndex] - samples[index])
-		if prevDir and nextDir then
-			local combined = prevDir + nextDir
-			if combined.Magnitude > 1e-4 then
-				return combined.Unit
-			end
-		end
-		return nextDir or prevDir or fallbackDir
-	end
-
-	if index == 1 then
-		return horizontalUnit(samples[2] - samples[1]) or fallbackDir
-	elseif index == edgeCount then
-		return horizontalUnit(samples[edgeCount] - samples[edgeCount - 1]) or fallbackDir
-	end
-
-	local prevDir = horizontalUnit(samples[index] - samples[index - 1])
-	local nextDir = horizontalUnit(samples[index + 1] - samples[index])
-	if prevDir and nextDir then
-		local combined = prevDir + nextDir
-		if combined.Magnitude > 1e-4 then
-			return combined.Unit
-		end
-	end
-	return nextDir or prevDir or fallbackDir
-end
-
-local function polylineLength(points, closedLoop)
-	local count = #points
-	if count < 2 then
-		return 0
-	end
-
-	local segmentCount = closedLoop and count or count - 1
-	local total = 0
-	for i = 1, segmentCount do
-		local nextIndex = closedLoop and ((i % count) + 1) or (i + 1)
-		total += (points[nextIndex] - points[i]).Magnitude
-	end
-	return total
-end
-
-local function samplePolylineAtFraction(points, closedLoop, fraction)
-	local count = #points
-	if count == 0 then
-		return Vector3.zero
-	elseif count == 1 then
-		return points[1]
-	end
-
-	local totalLength = polylineLength(points, closedLoop)
-	if totalLength <= 1e-4 then
-		return points[1]
-	end
-
-	local target = math.clamp(fraction, 0, 1) * totalLength
-	if closedLoop then
-		target = target % totalLength
-	elseif target <= 0 then
-		return points[1]
-	elseif target >= totalLength then
-		return points[count]
-	end
-
-	local traveled = 0
-	local segmentCount = closedLoop and count or count - 1
-	for i = 1, segmentCount do
-		local nextIndex = closedLoop and ((i % count) + 1) or (i + 1)
-		local a = points[i]
-		local b = points[nextIndex]
-		local segmentLength = (b - a).Magnitude
-		if segmentLength > 1e-4 then
-			if traveled + segmentLength >= target then
-				return a:Lerp(b, (target - traveled) / segmentLength)
-			end
-			traveled += segmentLength
-		end
-	end
-
-	return closedLoop and points[1] or points[count]
 end
 
 local function sampleSmoothedCurveControls(points, closedLoop, sampleStep)

--- a/src/client/MinimapController.lua
+++ b/src/client/MinimapController.lua
@@ -3,19 +3,17 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 local Workspace = game:GetService("Workspace")
 
-local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local Config = require(Shared:WaitForChild("Config"))
+local RoadSampling = require(Shared:WaitForChild("RoadSampling"))
+local RoadSplineData = require(Shared:WaitForChild("RoadSplineData"))
 
 local MinimapController = {}
 
 local WORLD_NAME = "Cab87World"
-local RUNTIME_SPLINE_DATA_NAME = "AuthoredRoadSplineData"
-local SPLINES_NAME = "Splines"
-local ROAD_POINTS_NAME = "RoadPoints"
-local ROAD_WIDTH_ATTR = "RoadWidth"
+local RUNTIME_SPLINE_DATA_NAME = RoadSplineData.RUNTIME_DATA_NAME
 
-local DEFAULT_ROAD_WIDTH = 28
-local MIN_ROAD_WIDTH = 8
-local MAX_ROAD_WIDTH = 200
+local DEFAULT_ROAD_WIDTH = RoadSampling.DEFAULT_ROAD_WIDTH
 
 local player = Players.LocalPlayer
 
@@ -46,137 +44,8 @@ local function getConfigString(key, fallback)
 	return fallback
 end
 
-local function sanitizeRoadWidth(value)
-	local width = tonumber(value) or DEFAULT_ROAD_WIDTH
-	return math.clamp(width, MIN_ROAD_WIDTH, MAX_ROAD_WIDTH)
-end
-
-local function sortedChildren(parent, className)
-	local children = {}
-	if not parent then
-		return children
-	end
-
-	for _, child in ipairs(parent:GetChildren()) do
-		if not className or child:IsA(className) then
-			table.insert(children, child)
-		end
-	end
-
-	table.sort(children, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return children
-end
-
-local function getAuthoredSplines(root)
-	local splinesFolder = root and root:FindFirstChild(SPLINES_NAME)
-	if splinesFolder and splinesFolder:IsA("Folder") then
-		return sortedChildren(splinesFolder, "Model")
-	end
-
-	local legacyPoints = root and root:FindFirstChild(ROAD_POINTS_NAME)
-	if legacyPoints and legacyPoints:IsA("Folder") then
-		return { root }
-	end
-
-	return {}
-end
-
-local function getAuthoredSplinePoints(spline)
-	local pointsFolder = spline and spline:FindFirstChild(ROAD_POINTS_NAME)
-	if not (pointsFolder and pointsFolder:IsA("Folder")) then
-		return {}
-	end
-
-	local points = {}
-	for _, child in ipairs(pointsFolder:GetChildren()) do
-		if child:IsA("BasePart") or child:IsA("Vector3Value") then
-			table.insert(points, child)
-		end
-	end
-
-	table.sort(points, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return points
-end
-
-local function getPointPosition(point)
-	if point:IsA("BasePart") then
-		return point.Position
-	end
-
-	return point.Value
-end
-
-local function distanceXZ(a, b)
-	local dx = a.X - b.X
-	local dz = a.Z - b.Z
-	return math.sqrt(dx * dx + dz * dz)
-end
-
-local function catmullRom(p0, p1, p2, p3, t)
-	local t2 = t * t
-	local t3 = t2 * t
-	return 0.5 * ((2 * p1) + (-p0 + p2) * t + (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 + (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
-end
-
-local function sampleAuthoredSpline(points, closedCurve)
-	local positions = {}
-	for _, point in ipairs(points) do
-		table.insert(positions, getPointPosition(point))
-	end
-
-	if #positions < 2 then
-		return positions
-	end
-
-	if closedCurve and #positions < 3 then
-		closedCurve = false
-	end
-
-	local samples = {}
-	local sampleStep = math.max(Config.authoredRoadSampleStepStuds or 8, 1)
-	if closedCurve then
-		local count = #positions
-		for i = 1, count do
-			local p0 = positions[((i - 2) % count) + 1]
-			local p1 = positions[i]
-			local p2 = positions[(i % count) + 1]
-			local p3 = positions[((i + 1) % count) + 1]
-			local segmentLen = (p2 - p1).Magnitude
-			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
-
-			for s = 0, subdivisions - 1 do
-				table.insert(samples, catmullRom(p0, p1, p2, p3, s / subdivisions))
-			end
-		end
-
-		if #samples > 1 then
-			table.insert(samples, samples[1])
-		end
-	else
-		for i = 1, #positions - 1 do
-			local p0 = positions[math.max(1, i - 1)]
-			local p1 = positions[i]
-			local p2 = positions[i + 1]
-			local p3 = positions[math.min(#positions, i + 2)]
-			local segmentLen = (p2 - p1).Magnitude
-			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
-
-			for s = 0, subdivisions - 1 do
-				table.insert(samples, catmullRom(p0, p1, p2, p3, s / subdivisions))
-			end
-		end
-
-		table.insert(samples, positions[#positions])
-	end
-
-	return samples
-end
+local sortedChildren = RoadSplineData.sortedChildren
+local distanceXZ = RoadSampling.distanceXZ
 
 local function simplifySamples(samples)
 	local spacing = math.max(getConfigNumber("minimapRoadPointSpacing", 28), 1)
@@ -236,37 +105,26 @@ local function collectAuthoredRoadData(dataRoot)
 	local junctions = {}
 	local bounds = newBounds()
 
-	for _, spline in ipairs(getAuthoredSplines(dataRoot)) do
-		local points = getAuthoredSplinePoints(spline)
-		if #points >= 2 then
-			local samples = {}
-			if spline:GetAttribute("SampledRoadChain") == true then
-				for _, point in ipairs(points) do
-					table.insert(samples, getPointPosition(point))
-				end
-			else
-				samples = sampleAuthoredSpline(points, spline:GetAttribute("ClosedCurve") == true)
-			end
-
-			local width = sanitizeRoadWidth(spline:GetAttribute(ROAD_WIDTH_ATTR))
-			local simplified = simplifySamples(samples)
-			for i = 1, #simplified - 1 do
-				addRoadSegment(segments, bounds, simplified[i], simplified[i + 1], width)
-			end
+	for _, chain in ipairs(RoadSplineData.collectSampledChains(dataRoot, {
+		defaultRoadWidth = RoadSampling.getConfiguredRoadWidth(Config),
+		sampleStep = Config.authoredRoadSampleStepStuds,
+	})) do
+		local simplified = simplifySamples(chain.samples)
+		for i = 1, #simplified - 1 do
+			addRoadSegment(segments, bounds, simplified[i], simplified[i + 1], chain.width)
 		end
 	end
 
-	local junctionsFolder = dataRoot:FindFirstChild("Junctions")
-	if junctionsFolder and junctionsFolder:IsA("Folder") then
-		for _, junctionData in ipairs(sortedChildren(junctionsFolder, "Vector3Value")) do
-			local radius = math.max(tonumber(junctionData:GetAttribute("Radius")) or DEFAULT_ROAD_WIDTH * 0.5, 2)
-			table.insert(junctions, {
-				x = junctionData.Value.X,
-				z = junctionData.Value.Z,
-				radius = radius,
-			})
-			includePosition(bounds, junctionData.Value, radius)
-		end
+	for _, junction in ipairs(RoadSplineData.collectJunctions(dataRoot, {
+		defaultRadius = DEFAULT_ROAD_WIDTH * 0.5,
+		minRadius = 2,
+	})) do
+		table.insert(junctions, {
+			x = junction.center.X,
+			z = junction.center.Z,
+			radius = junction.radius,
+		})
+		includePosition(bounds, junction.center, junction.radius)
 	end
 
 	return {

--- a/src/server/AuthoredRoadRuntime.lua
+++ b/src/server/AuthoredRoadRuntime.lua
@@ -1,21 +1,23 @@
 local AssetService = game:GetService("AssetService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Workspace = game:GetService("Workspace")
 
-local Config = require(game:GetService("ReplicatedStorage"):WaitForChild("Shared"):WaitForChild("Config"))
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local Config = require(Shared:WaitForChild("Config"))
+local RoadSampling = require(Shared:WaitForChild("RoadSampling"))
+local RoadSplineData = require(Shared:WaitForChild("RoadSplineData"))
 
 local AuthoredRoadRuntime = {}
 
-local ROAD_EDITOR_ROOT_NAME = "Cab87RoadEditor"
-local ROAD_EDITOR_SPLINES_NAME = "Splines"
-local ROAD_EDITOR_POINTS_NAME = "RoadPoints"
-local ROAD_EDITOR_NETWORK_NAME = "RoadNetwork"
-local ROAD_EDITOR_WIREFRAME_NAME = "WireframeDisplay"
-local ROAD_WIDTH_ATTR = "RoadWidth"
+local ROAD_EDITOR_ROOT_NAME = RoadSplineData.EDITOR_ROOT_NAME
+local ROAD_EDITOR_SPLINES_NAME = RoadSplineData.SPLINES_NAME
+local ROAD_EDITOR_POINTS_NAME = RoadSplineData.POINTS_NAME
+local ROAD_EDITOR_NETWORK_NAME = RoadSplineData.NETWORK_NAME
+local ROAD_EDITOR_WIREFRAME_NAME = RoadSplineData.WIREFRAME_NAME
+local ROAD_WIDTH_ATTR = RoadSplineData.ROAD_WIDTH_ATTR
 local RUNTIME_WORLD_NAME = "Cab87World"
-local RUNTIME_SPLINE_DATA_NAME = "AuthoredRoadSplineData"
-local DEFAULT_AUTHORED_ROAD_WIDTH = 28
-local AUTHORED_ROAD_MIN_WIDTH = 8
-local AUTHORED_ROAD_MAX_WIDTH = 200
+local RUNTIME_SPLINE_DATA_NAME = RoadSplineData.RUNTIME_DATA_NAME
+local DEFAULT_AUTHORED_ROAD_WIDTH = RoadSampling.DEFAULT_ROAD_WIDTH
 local VISUAL_ROAD_THICKNESS = 0.35
 local VISUAL_ROAD_SURFACE_OFFSET = 0.72
 local ROAD_MESH_THICKNESS = 1.2
@@ -71,49 +73,28 @@ local function makePart(parent, props)
 	return part
 end
 
-local function sortedChildren(parent, className)
-	local children = {}
-	if not parent then
-		return children
-	end
+local sortedChildren = RoadSplineData.sortedChildren
+local getAuthoredSplines = RoadSplineData.getSplines
+local getAuthoredSplinePoints = RoadSplineData.getSplinePoints
+local distanceXZ = RoadSampling.distanceXZ
+local horizontalUnit = RoadSampling.horizontalUnit
+local catmullRom = RoadSampling.catmullRom
+local sampleLoopIsClosed = RoadSampling.sampleLoopIsClosed
+local getRoadSampleTangent = RoadSampling.getRoadSampleTangent
+local polylineLength = RoadSampling.polylineLength
+local samplePolylineAtFraction = RoadSampling.samplePolylineAtFraction
 
-	for _, child in ipairs(parent:GetChildren()) do
-		if not className or child:IsA(className) then
-			table.insert(children, child)
-		end
-	end
-
-	table.sort(children, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return children
+local function getSplineRoadWidth(spline)
+	return RoadSampling.getSplineRoadWidth(spline, RoadSampling.getConfiguredRoadWidth(Config))
 end
 
-local function getAuthoredSplines(root)
-	local splinesFolder = root and root:FindFirstChild(ROAD_EDITOR_SPLINES_NAME)
-	if splinesFolder and splinesFolder:IsA("Folder") then
-		return sortedChildren(splinesFolder, "Model")
-	end
-
-	local legacyPoints = root and root:FindFirstChild(ROAD_EDITOR_POINTS_NAME)
-	if legacyPoints and legacyPoints:IsA("Folder") then
-		return { root }
-	end
-
-	return {}
+local function sampleAuthoredSpline(points, closedCurve)
+	return RoadSampling.samplePositions(
+		RoadSplineData.getPointPositions(points),
+		closedCurve,
+		Config.authoredRoadSampleStepStuds
+	)
 end
-
-local function getAuthoredSplinePoints(spline)
-	local pointsFolder = spline and spline:FindFirstChild(ROAD_EDITOR_POINTS_NAME)
-	if not (pointsFolder and pointsFolder:IsA("Folder")) then
-		return {}
-	end
-
-	return sortedChildren(pointsFolder, "BasePart")
-end
-
-local getSplineRoadWidth
 
 local function createReplicatedSplineData(root, world)
 	local oldData = world:FindFirstChild(RUNTIME_SPLINE_DATA_NAME)
@@ -149,7 +130,7 @@ local function createReplicatedSplineData(root, world)
 				pointCount += 1
 				local pointData = Instance.new("Vector3Value")
 				pointData.Name = point.Name
-				pointData.Value = point.Position
+				pointData.Value = RoadSplineData.getPointPosition(point)
 				pointData.Parent = pointsData
 			end
 		end
@@ -188,15 +169,7 @@ local function countRoadSurfaceParts(root)
 	return count
 end
 
-local function sanitizeRoadWidth(value)
-	local width = tonumber(value) or DEFAULT_AUTHORED_ROAD_WIDTH
-	return math.clamp(width, AUTHORED_ROAD_MIN_WIDTH, AUTHORED_ROAD_MAX_WIDTH)
-end
-
-function getSplineRoadWidth(spline)
-	local configuredDefault = tonumber(Config.authoredRoadCollisionWidth) or DEFAULT_AUTHORED_ROAD_WIDTH
-	return sanitizeRoadWidth(tonumber(spline and spline:GetAttribute(ROAD_WIDTH_ATTR)) or configuredDefault)
-end
+local sanitizeRoadWidth = RoadSampling.sanitizeRoadWidth
 
 local function hasAssetBackedMesh(part)
 	if not part:IsA("MeshPart") then
@@ -227,66 +200,6 @@ local function removeEditorDebugVisuals(root)
 	end
 end
 
-local function catmullRom(p0, p1, p2, p3, t)
-	local t2 = t * t
-	local t3 = t2 * t
-	return 0.5 * ((2 * p1) + (-p0 + p2) * t + (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 + (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
-end
-
-local function sampleAuthoredSpline(points, closedCurve)
-	local positions = {}
-	for _, point in ipairs(points) do
-		table.insert(positions, point.Position)
-	end
-
-	if #positions < 2 then
-		return positions
-	end
-
-	if closedCurve and #positions < 3 then
-		closedCurve = false
-	end
-
-	local samples = {}
-	local sampleStep = math.max(Config.authoredRoadSampleStepStuds, 1)
-	if closedCurve then
-		local count = #positions
-		for i = 1, count do
-			local p0 = positions[((i - 2) % count) + 1]
-			local p1 = positions[i]
-			local p2 = positions[(i % count) + 1]
-			local p3 = positions[((i + 1) % count) + 1]
-			local segmentLen = (p2 - p1).Magnitude
-			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
-
-			for s = 0, subdivisions - 1 do
-				table.insert(samples, catmullRom(p0, p1, p2, p3, s / subdivisions))
-			end
-		end
-
-		if #samples > 1 then
-			table.insert(samples, samples[1])
-		end
-	else
-		for i = 1, #positions - 1 do
-			local p0 = positions[math.max(1, i - 1)]
-			local p1 = positions[i]
-			local p2 = positions[i + 1]
-			local p3 = positions[math.min(#positions, i + 2)]
-			local segmentLen = (p2 - p1).Magnitude
-			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
-
-			for s = 0, subdivisions - 1 do
-				table.insert(samples, catmullRom(p0, p1, p2, p3, s / subdivisions))
-			end
-		end
-
-		table.insert(samples, positions[#positions])
-	end
-
-	return samples
-end
-
 local function configureRuntimePart(part, canQuery)
 	part.Anchored = true
 	part.CanCollide = canQuery
@@ -297,12 +210,6 @@ end
 local function trackPart(list, part)
 	table.insert(list, part)
 	return part
-end
-
-local function distanceXZ(a, b)
-	local dx = a.X - b.X
-	local dz = a.Z - b.Z
-	return math.sqrt(dx * dx + dz * dz)
 end
 
 local function heightConnectTolerance(widthA, widthB)
@@ -319,21 +226,11 @@ local function positionsConnectIn3D(a, b, widthA, widthB)
 end
 
 local function collectSplineBuildData(root)
-	local chains = {}
-	for _, spline in ipairs(getAuthoredSplines(root)) do
-		local points = getAuthoredSplinePoints(spline)
-		if #points >= 2 then
-			local closed = spline:GetAttribute("ClosedCurve") == true
-			table.insert(chains, {
-				spline = spline,
-				points = points,
-				samples = sampleAuthoredSpline(points, closed),
-				closed = closed,
-				width = getSplineRoadWidth(spline),
-			})
-		end
-	end
-	return chains
+	return RoadSplineData.collectSampledChains(root, {
+		defaultRoadWidth = RoadSampling.getConfiguredRoadWidth(Config),
+		preserveSampledChains = false,
+		sampleStep = Config.authoredRoadSampleStepStuds,
+	})
 end
 
 local function getChainName(chain, fallback)
@@ -622,13 +519,6 @@ local function addMeshTriangle(state, a, b, c)
 	state.faces += 1
 end
 
-local function sampleLoopIsClosed(samples)
-	if #samples < 3 then
-		return false
-	end
-	return distanceXZ(samples[1], samples[#samples]) <= 0.05 and math.abs(samples[1].Y - samples[#samples].Y) <= 0.05
-end
-
 local function roadRightFromTangent(tangent)
 	local right = Vector3.yAxis:Cross(tangent)
 	if right.Magnitude < 1e-4 then
@@ -637,113 +527,12 @@ local function roadRightFromTangent(tangent)
 	return right.Unit
 end
 
-local function horizontalUnit(vector)
-	local flat = Vector3.new(vector.X, 0, vector.Z)
-	if flat.Magnitude < 1e-4 then
-		return nil
-	end
-	return flat.Unit
-end
-
 local function addRoadLoftRowVertices(state, left, right, widthSegments)
 	local row = {}
 	for j = 0, widthSegments do
 		row[j + 1] = addMeshVertex(state, left:Lerp(right, j / widthSegments))
 	end
 	return row
-end
-
-local function getRoadSampleTangent(samples, index, edgeCount, closedLoop, fallbackDir)
-	if closedLoop then
-		local prevIndex = index - 1
-		if prevIndex < 1 then
-			prevIndex = edgeCount
-		end
-		local nextIndex = index + 1
-		if nextIndex > edgeCount then
-			nextIndex = 1
-		end
-		local prevDir = horizontalUnit(samples[index] - samples[prevIndex])
-		local nextDir = horizontalUnit(samples[nextIndex] - samples[index])
-		if prevDir and nextDir then
-			local combined = prevDir + nextDir
-			if combined.Magnitude > 1e-4 then
-				return combined.Unit
-			end
-		end
-		return nextDir or prevDir or fallbackDir
-	end
-
-	if index == 1 then
-		return horizontalUnit(samples[2] - samples[1]) or fallbackDir
-	elseif index == edgeCount then
-		return horizontalUnit(samples[edgeCount] - samples[edgeCount - 1]) or fallbackDir
-	end
-
-	local prevDir = horizontalUnit(samples[index] - samples[index - 1])
-	local nextDir = horizontalUnit(samples[index + 1] - samples[index])
-	if prevDir and nextDir then
-		local combined = prevDir + nextDir
-		if combined.Magnitude > 1e-4 then
-			return combined.Unit
-		end
-	end
-	return nextDir or prevDir or fallbackDir
-end
-
-local function polylineLength(points, closedLoop)
-	local count = #points
-	if count < 2 then
-		return 0
-	end
-
-	local segmentCount = closedLoop and count or count - 1
-	local total = 0
-	for i = 1, segmentCount do
-		local nextIndex = closedLoop and ((i % count) + 1) or (i + 1)
-		total += (points[nextIndex] - points[i]).Magnitude
-	end
-	return total
-end
-
-local function samplePolylineAtFraction(points, closedLoop, fraction)
-	local count = #points
-	if count == 0 then
-		return Vector3.zero
-	elseif count == 1 then
-		return points[1]
-	end
-
-	local totalLength = polylineLength(points, closedLoop)
-	if totalLength <= 1e-4 then
-		return points[1]
-	end
-
-	local target = math.clamp(fraction, 0, 1) * totalLength
-	if closedLoop then
-		target = target % totalLength
-	elseif target <= 0 then
-		return points[1]
-	elseif target >= totalLength then
-		return points[count]
-	end
-
-	local traveled = 0
-	local segmentCount = closedLoop and count or count - 1
-	for i = 1, segmentCount do
-		local nextIndex = closedLoop and ((i % count) + 1) or (i + 1)
-		local a = points[i]
-		local b = points[nextIndex]
-		local segmentLength = (b - a).Magnitude
-		if segmentLength > 1e-4 then
-			if traveled + segmentLength >= target then
-				return a:Lerp(b, (target - traveled) / segmentLength)
-			end
-			traveled += segmentLength
-		end
-	end
-
-	return closedLoop and points[1] or points[count]
 end
 
 local function sampleSmoothedCurveControls(points, closedLoop, sampleStep)
@@ -1592,11 +1381,12 @@ local function findFirstSpawn(root)
 	for _, spline in ipairs(getAuthoredSplines(root)) do
 		local points = getAuthoredSplinePoints(spline)
 		if #points > 0 then
-			local spawnPosition = points[1].Position + Vector3.new(0, Config.carRideHeight, 0)
+			local firstPosition = RoadSplineData.getPointPosition(points[1])
+			local spawnPosition = firstPosition + Vector3.new(0, Config.carRideHeight, 0)
 			local spawnYaw = 0
 
 			if #points >= 2 then
-				local delta = points[2].Position - points[1].Position
+				local delta = RoadSplineData.getPointPosition(points[2]) - firstPosition
 				local horizontal = Vector3.new(delta.X, 0, delta.Z)
 				if horizontal.Magnitude > 0.001 then
 					spawnYaw = vectorToYaw(horizontal.Unit)
@@ -1668,7 +1458,7 @@ local function buildGeneratedRoadVisuals(root, world)
 
 		for _, point in ipairs(points) do
 			capIndex += 1
-			createVisualCap(visualModel, point.Position, capIndex, width)
+			createVisualCap(visualModel, RoadSplineData.getPointPosition(point), capIndex, width)
 		end
 	end
 
@@ -1704,7 +1494,7 @@ local function buildCollision(root, world, driveSurfaces, visible)
 
 		for _, point in ipairs(points) do
 			capIndex += 1
-			trackPart(driveSurfaces, createCollisionCap(collisionModel, point.Position, capIndex, width, visible))
+			trackPart(driveSurfaces, createCollisionCap(collisionModel, RoadSplineData.getPointPosition(point), capIndex, width, visible))
 		end
 	end
 

--- a/src/server/GpsService.lua
+++ b/src/server/GpsService.lua
@@ -2,13 +2,15 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 local Workspace = game:GetService("Workspace")
 
-local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local Config = require(Shared:WaitForChild("Config"))
+local RoadGraph = require(Shared:WaitForChild("RoadGraph"))
+local RoadSampling = require(Shared:WaitForChild("RoadSampling"))
+local RoadSplineData = require(Shared:WaitForChild("RoadSplineData"))
 
 local GpsService = {}
 
-local ROAD_SPLINE_DATA_NAME = "AuthoredRoadSplineData"
-local ROAD_SPLINES_NAME = "Splines"
-local ROAD_POINTS_NAME = "RoadPoints"
+local ROAD_SPLINE_DATA_NAME = RoadSplineData.RUNTIME_DATA_NAME
 local GPS_BASE_TRANSPARENCY_ATTR = "Cab87BaseTransparency"
 
 local function getConfigNumber(key, fallback)
@@ -38,36 +40,7 @@ local function getConfigColor(key, fallback)
 	return fallback
 end
 
-local function horizontalDistance(a, b)
-	local dx = a.X - b.X
-	local dz = a.Z - b.Z
-	return math.sqrt(dx * dx + dz * dz)
-end
-
-local function horizontalDistanceSquared(a, b)
-	local dx = a.X - b.X
-	local dz = a.Z - b.Z
-	return dx * dx + dz * dz
-end
-
-local function sortedChildren(parent, className)
-	local children = {}
-	if not parent then
-		return children
-	end
-
-	for _, child in ipairs(parent:GetChildren()) do
-		if not className or child:IsA(className) then
-			table.insert(children, child)
-		end
-	end
-
-	table.sort(children, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return children
-end
+local horizontalDistance = RoadSampling.distanceXZ
 
 local function setPartRuntimeDefaults(part)
 	part.Anchored = true
@@ -134,165 +107,32 @@ local function recreateModel(parent, name)
 	return model
 end
 
-local function getRoutePointPosition(point)
-	if point:IsA("BasePart") then
-		return point.Position
-	end
-
-	return point.Value
-end
-
-local function getRouteBucketKey(ix, iz)
-	return tostring(ix) .. ":" .. tostring(iz)
-end
-
 local function newRouteGraph()
-	local mergeDistance = math.max(getConfigNumber("passengerRouteGraphNodeMergeDistance", 5), 0)
-	local bucketSize = math.max(mergeDistance, 4)
-	return {
-		nodes = {},
-		edges = {},
-		edgeLookup = {},
-		nodeBuckets = {},
-		bucketSize = bucketSize,
-		mergeDistance = mergeDistance,
-		maxMergeHeight = math.max(getConfigNumber("passengerRouteGraphMaxMergeHeight", 7), 0),
-	}
+	return RoadGraph.new({
+		mergeDistance = getConfigNumber("passengerRouteGraphNodeMergeDistance", 5),
+		maxMergeHeight = getConfigNumber("passengerRouteGraphMaxMergeHeight", 7),
+	})
 end
 
-local function getNearbyRouteNodeIds(graph, position, radius)
-	local bucketSize = graph.bucketSize
-	local bucketRadius = math.max(1, math.ceil(radius / bucketSize))
-	local centerX = math.floor(position.X / bucketSize)
-	local centerZ = math.floor(position.Z / bucketSize)
-	local nodeIds = {}
-
-	for x = centerX - bucketRadius, centerX + bucketRadius do
-		for z = centerZ - bucketRadius, centerZ + bucketRadius do
-			local bucket = graph.nodeBuckets[getRouteBucketKey(x, z)]
-			if bucket then
-				for _, nodeId in ipairs(bucket) do
-					table.insert(nodeIds, nodeId)
-				end
-			end
-		end
-	end
-
-	return nodeIds
-end
-
-local function addRouteNode(graph, position)
-	local mergeDistance = graph.mergeDistance
-	if mergeDistance > 0 then
-		for _, nodeId in ipairs(getNearbyRouteNodeIds(graph, position, mergeDistance)) do
-			local node = graph.nodes[nodeId]
-			if node
-				and math.abs(node.position.Y - position.Y) <= graph.maxMergeHeight
-				and horizontalDistance(node.position, position) <= mergeDistance
-			then
-				return nodeId
-			end
-		end
-	end
-
-	local nodeId = #graph.nodes + 1
-	graph.nodes[nodeId] = {
-		position = position,
-		neighbors = {},
-	}
-
-	local ix = math.floor(position.X / graph.bucketSize)
-	local iz = math.floor(position.Z / graph.bucketSize)
-	local key = getRouteBucketKey(ix, iz)
-	local bucket = graph.nodeBuckets[key]
-	if not bucket then
-		bucket = {}
-		graph.nodeBuckets[key] = bucket
-	end
-	table.insert(bucket, nodeId)
-
-	return nodeId
-end
-
-local function addRouteEdge(graph, a, b)
-	if not a or not b or a == b then
-		return
-	end
-
-	local key = if a < b then tostring(a) .. ":" .. tostring(b) else tostring(b) .. ":" .. tostring(a)
-	if graph.edgeLookup[key] then
-		return
-	end
-
-	local aPosition = graph.nodes[a].position
-	local bPosition = graph.nodes[b].position
-	local cost = horizontalDistance(aPosition, bPosition)
-	if cost <= 0.1 then
-		return
-	end
-
-	graph.edgeLookup[key] = true
-	table.insert(graph.nodes[a].neighbors, { id = b, cost = cost })
-	table.insert(graph.nodes[b].neighbors, { id = a, cost = cost })
-	table.insert(graph.edges, { a = a, b = b, cost = cost })
-end
-
-local function connectRouteJunction(graph, center, radius)
-	local junctionId = addRouteNode(graph, center)
-	local connectRadius = math.max(radius + getConfigNumber("passengerRouteJunctionExtraRadius", 10), graph.mergeDistance)
-
-	for _, nodeId in ipairs(getNearbyRouteNodeIds(graph, center, connectRadius)) do
-		local node = graph.nodes[nodeId]
-		if nodeId ~= junctionId
-			and node
-			and math.abs(node.position.Y - center.Y) <= graph.maxMergeHeight
-			and horizontalDistance(node.position, center) <= connectRadius
-		then
-			addRouteEdge(graph, junctionId, nodeId)
-		end
-	end
-end
+local addRouteNode = RoadGraph.addNode
+local addRouteEdge = RoadGraph.addEdge
 
 local function buildAuthoredRouteGraph(world)
 	local dataRoot = world:FindFirstChild(ROAD_SPLINE_DATA_NAME)
-	local splinesFolder = dataRoot and dataRoot:FindFirstChild(ROAD_SPLINES_NAME)
-	if not (splinesFolder and splinesFolder:IsA("Folder")) then
+	if not dataRoot then
+		return nil
+	end
+
+	local records = RoadSplineData.collectSplineRecords(dataRoot)
+	if #records == 0 then
 		return nil
 	end
 
 	local graph = newRouteGraph()
-	for _, spline in ipairs(sortedChildren(splinesFolder, "Model")) do
-		local pointsFolder = spline:FindFirstChild(ROAD_POINTS_NAME)
-		local points = sortedChildren(pointsFolder, nil)
-		local firstNodeId = nil
-		local previousNodeId = nil
+	RoadGraph.addSplineRecords(graph, records)
 
-		for _, point in ipairs(points) do
-			if point:IsA("BasePart") or point:IsA("Vector3Value") then
-				local nodeId = addRouteNode(graph, getRoutePointPosition(point))
-				if not firstNodeId then
-					firstNodeId = nodeId
-				end
-
-				if previousNodeId then
-					addRouteEdge(graph, previousNodeId, nodeId)
-				end
-
-				previousNodeId = nodeId
-			end
-		end
-
-		if firstNodeId and previousNodeId and firstNodeId ~= previousNodeId and spline:GetAttribute("ClosedCurve") == true then
-			addRouteEdge(graph, previousNodeId, firstNodeId)
-		end
-	end
-
-	local junctionsFolder = dataRoot:FindFirstChild("Junctions")
-	if junctionsFolder and junctionsFolder:IsA("Folder") then
-		for _, junctionData in ipairs(sortedChildren(junctionsFolder, "Vector3Value")) do
-			local radius = math.max(tonumber(junctionData:GetAttribute("Radius")) or 0, 0)
-			connectRouteJunction(graph, junctionData.Value, radius)
-		end
+	for _, junction in ipairs(RoadSplineData.collectJunctions(dataRoot, { defaultRadius = 0, minRadius = 0 })) do
+		RoadGraph.connectJunction(graph, junction.center, junction.radius, getConfigNumber("passengerRouteJunctionExtraRadius", 10))
 	end
 
 	if #graph.nodes == 0 or #graph.edges == 0 then
@@ -542,232 +382,6 @@ local function getSurfacePosition(service, position, fallbackY)
 	return Vector3.new(position.X, fallbackY or position.Y, position.Z)
 end
 
-local function projectPointToRouteSegment(position, a, b)
-	local dx = b.X - a.X
-	local dz = b.Z - a.Z
-	local lengthSquared = dx * dx + dz * dz
-	if lengthSquared <= 0.001 then
-		return a, 0, horizontalDistance(position, a)
-	end
-
-	local alpha = math.clamp(((position.X - a.X) * dx + (position.Z - a.Z) * dz) / lengthSquared, 0, 1)
-	local projected = Vector3.new(
-		a.X + dx * alpha,
-		a.Y + (b.Y - a.Y) * alpha,
-		a.Z + dz * alpha
-	)
-	return projected, alpha, horizontalDistance(position, projected)
-end
-
-local function findNearestRouteEdge(graph, position)
-	if not graph then
-		return nil
-	end
-
-	local best = nil
-	local bestScore = math.huge
-	for _, edge in ipairs(graph.edges) do
-		local a = graph.nodes[edge.a].position
-		local b = graph.nodes[edge.b].position
-		local projected, alpha, distance = projectPointToRouteSegment(position, a, b)
-		local verticalPenalty = math.abs(position.Y - projected.Y) * 0.08
-		local score = distance + verticalPenalty
-		if score < bestScore then
-			bestScore = score
-			best = {
-				edge = edge,
-				position = projected,
-				alpha = alpha,
-				distance = distance,
-			}
-		end
-	end
-
-	return best
-end
-
-local function findNearestRouteNode(graph, position)
-	local bestNodeId = nil
-	local bestScore = math.huge
-
-	for nodeId, node in ipairs(graph.nodes) do
-		local score = horizontalDistanceSquared(position, node.position)
-		if score < bestScore then
-			bestScore = score
-			bestNodeId = nodeId
-		end
-	end
-
-	return bestNodeId
-end
-
-local function addTemporaryRouteConnection(neighbors, a, b, cost)
-	if not a or not b or a == b then
-		return
-	end
-
-	neighbors[a] = neighbors[a] or {}
-	neighbors[b] = neighbors[b] or {}
-	table.insert(neighbors[a], { id = b, cost = cost })
-	table.insert(neighbors[b], { id = a, cost = cost })
-end
-
-local function connectTemporaryRouteNode(graph, neighbors, nodeId, position)
-	local snap = findNearestRouteEdge(graph, position)
-	if snap then
-		local a = graph.nodes[snap.edge.a].position
-		local b = graph.nodes[snap.edge.b].position
-		addTemporaryRouteConnection(neighbors, nodeId, snap.edge.a, horizontalDistance(snap.position, a))
-		addTemporaryRouteConnection(neighbors, nodeId, snap.edge.b, horizontalDistance(snap.position, b))
-		return snap
-	end
-
-	local nearestNodeId = findNearestRouteNode(graph, position)
-	if nearestNodeId then
-		addTemporaryRouteConnection(neighbors, nodeId, nearestNodeId, horizontalDistance(position, graph.nodes[nearestNodeId].position))
-	end
-
-	return nil
-end
-
-local function heapPush(heap, item)
-	table.insert(heap, item)
-	local index = #heap
-	while index > 1 do
-		local parent = math.floor(index * 0.5)
-		if heap[parent].cost <= item.cost then
-			break
-		end
-		heap[index] = heap[parent]
-		index = parent
-	end
-	heap[index] = item
-end
-
-local function heapPop(heap)
-	local root = heap[1]
-	if not root then
-		return nil
-	end
-
-	local last = table.remove(heap)
-	if #heap == 0 then
-		return root
-	end
-
-	local index = 1
-	while true do
-		local left = index * 2
-		local right = left + 1
-		if left > #heap then
-			break
-		end
-
-		local child = left
-		if right <= #heap and heap[right].cost < heap[left].cost then
-			child = right
-		end
-
-		if heap[child].cost >= last.cost then
-			break
-		end
-
-		heap[index] = heap[child]
-		index = child
-	end
-
-	heap[index] = last
-	return root
-end
-
-local function getRouteNodePosition(graph, temporaryPositions, nodeId)
-	return temporaryPositions[nodeId] or graph.nodes[nodeId].position
-end
-
-local function findRoutePath(graph, startPosition, targetPosition)
-	if not graph or #graph.nodes == 0 or #graph.edges == 0 then
-		return nil
-	end
-
-	local startId = #graph.nodes + 1
-	local targetId = #graph.nodes + 2
-	local temporaryPositions = {
-		[startId] = startPosition,
-		[targetId] = targetPosition,
-	}
-	local temporaryNeighbors = {}
-	local startSnap = connectTemporaryRouteNode(graph, temporaryNeighbors, startId, startPosition)
-	local targetSnap = connectTemporaryRouteNode(graph, temporaryNeighbors, targetId, targetPosition)
-
-	if startSnap then
-		temporaryPositions[startId] = startSnap.position
-	end
-	if targetSnap then
-		temporaryPositions[targetId] = targetSnap.position
-	end
-	if startSnap and targetSnap and startSnap.edge == targetSnap.edge then
-		addTemporaryRouteConnection(
-			temporaryNeighbors,
-			startId,
-			targetId,
-			horizontalDistance(temporaryPositions[startId], temporaryPositions[targetId])
-		)
-	end
-
-	local distances = {
-		[startId] = 0,
-	}
-	local previous = {}
-	local heap = {}
-	heapPush(heap, { id = startId, cost = 0 })
-
-	local function relax(fromId, neighbor)
-		local nextCost = distances[fromId] + neighbor.cost
-		if not distances[neighbor.id] or nextCost < distances[neighbor.id] then
-			distances[neighbor.id] = nextCost
-			previous[neighbor.id] = fromId
-			heapPush(heap, { id = neighbor.id, cost = nextCost })
-		end
-	end
-
-	while #heap > 0 do
-		local current = heapPop(heap)
-		if current and current.cost == distances[current.id] then
-			if current.id == targetId then
-				break
-			end
-
-			if current.id <= #graph.nodes then
-				for _, neighbor in ipairs(graph.nodes[current.id].neighbors) do
-					relax(current.id, neighbor)
-				end
-			end
-
-			for _, neighbor in ipairs(temporaryNeighbors[current.id] or {}) do
-				relax(current.id, neighbor)
-			end
-		end
-	end
-
-	if not distances[targetId] then
-		return nil
-	end
-
-	local reversed = {}
-	local nodeId = targetId
-	while nodeId do
-		table.insert(reversed, getRouteNodePosition(graph, temporaryPositions, nodeId))
-		nodeId = previous[nodeId]
-	end
-
-	local path = {}
-	for i = #reversed, 1, -1 do
-		table.insert(path, reversed[i])
-	end
-
-	return path
-end
-
 local function getHorizontalDirection(fromPosition, toPosition)
 	local delta = Vector3.new(toPosition.X - fromPosition.X, 0, toPosition.Z - fromPosition.Z)
 	if delta.Magnitude <= 0.001 then
@@ -837,7 +451,7 @@ local function updateRouteLine(service, cabPosition, targetPosition)
 		return
 	end
 
-	local routePath = findRoutePath(service.routeGraph, cabPosition, targetPosition)
+	local routePath = RoadGraph.findPath(service.routeGraph, cabPosition, targetPosition)
 	if not routePath or #routePath < 2 then
 		for _, segment in ipairs(guide.segments) do
 			setRouteSegmentVisible(segment, false)

--- a/src/server/PassengerService.lua
+++ b/src/server/PassengerService.lua
@@ -2,14 +2,15 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 local Workspace = game:GetService("Workspace")
 
-local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local Config = require(Shared:WaitForChild("Config"))
+local RoadSampling = require(Shared:WaitForChild("RoadSampling"))
+local RoadSplineData = require(Shared:WaitForChild("RoadSplineData"))
 local PassengerVisuals = require(script.Parent:WaitForChild("PassengerVisuals"))
 
 local PassengerService = {}
 
-local ROAD_SPLINE_DATA_NAME = "AuthoredRoadSplineData"
-local ROAD_SPLINES_NAME = "Splines"
-local ROAD_POINTS_NAME = "RoadPoints"
+local ROAD_SPLINE_DATA_NAME = RoadSplineData.RUNTIME_DATA_NAME
 
 local function getConfigNumber(key, fallback)
 	local value = Config[key]
@@ -29,11 +30,7 @@ local function getConfigString(key, fallback)
 	return fallback
 end
 
-local function horizontalDistance(a, b)
-	local dx = a.X - b.X
-	local dz = a.Z - b.Z
-	return math.sqrt(dx * dx + dz * dz)
-end
+local horizontalDistance = RoadSampling.distanceXZ
 
 local function getPassengerStopReservationDistance()
 	local pickupRadius = math.max(getConfigNumber("passengerPickupRadius", 24), 1)
@@ -52,25 +49,6 @@ local function horizontalUnit(vector)
 	return horizontal / magnitude
 end
 
-local function sortedChildren(parent, className)
-	local children = {}
-	if not parent then
-		return children
-	end
-
-	for _, child in ipairs(parent:GetChildren()) do
-		if not className or child:IsA(className) then
-			table.insert(children, child)
-		end
-	end
-
-	table.sort(children, function(a, b)
-		return a.Name < b.Name
-	end)
-
-	return children
-end
-
 local function addCandidate(candidates, position, minSeparation)
 	for _, candidate in ipairs(candidates) do
 		if horizontalDistance(candidate, position) < minSeparation then
@@ -86,19 +64,15 @@ local function collectAuthoredRoadCandidates(world, minSeparation)
 	local candidates = {}
 	local spacing = math.max(getConfigNumber("passengerStopSpacing", 160), 24)
 	local dataRoot = world:FindFirstChild(ROAD_SPLINE_DATA_NAME)
-	local splinesFolder = dataRoot and dataRoot:FindFirstChild(ROAD_SPLINES_NAME)
-	if not (splinesFolder and splinesFolder:IsA("Folder")) then
+	if not dataRoot then
 		return candidates
 	end
 
-	for _, spline in ipairs(sortedChildren(splinesFolder, "Model")) do
-		local pointsFolder = spline:FindFirstChild(ROAD_POINTS_NAME)
-		local points = sortedChildren(pointsFolder, "Vector3Value")
+	for _, record in ipairs(RoadSplineData.collectSplineRecords(dataRoot)) do
 		local distanceSinceLastStop = spacing
 		local previousPosition = nil
 
-		for _, point in ipairs(points) do
-			local position = point.Value
+		for _, position in ipairs(record.positions) do
 			if previousPosition then
 				distanceSinceLastStop += horizontalDistance(position, previousPosition)
 			end

--- a/src/shared/RoadGraph.lua
+++ b/src/shared/RoadGraph.lua
@@ -1,0 +1,350 @@
+local RoadSampling = require(script.Parent:WaitForChild("RoadSampling"))
+
+local RoadGraph = {}
+
+local function getBucketKey(ix, iz)
+	return tostring(ix) .. ":" .. tostring(iz)
+end
+
+function RoadGraph.new(options)
+	options = options or {}
+	local mergeDistance = math.max(tonumber(options.mergeDistance) or 0, 0)
+	local bucketSize = math.max(tonumber(options.bucketSize) or mergeDistance, 4)
+	return {
+		nodes = {},
+		edges = {},
+		edgeLookup = {},
+		nodeBuckets = {},
+		bucketSize = bucketSize,
+		mergeDistance = mergeDistance,
+		maxMergeHeight = math.max(tonumber(options.maxMergeHeight) or 0, 0),
+	}
+end
+
+function RoadGraph.getNearbyNodeIds(graph, position, radius)
+	local bucketSize = graph.bucketSize
+	local bucketRadius = math.max(1, math.ceil(radius / bucketSize))
+	local centerX = math.floor(position.X / bucketSize)
+	local centerZ = math.floor(position.Z / bucketSize)
+	local nodeIds = {}
+
+	for x = centerX - bucketRadius, centerX + bucketRadius do
+		for z = centerZ - bucketRadius, centerZ + bucketRadius do
+			local bucket = graph.nodeBuckets[getBucketKey(x, z)]
+			if bucket then
+				for _, nodeId in ipairs(bucket) do
+					table.insert(nodeIds, nodeId)
+				end
+			end
+		end
+	end
+
+	return nodeIds
+end
+
+function RoadGraph.addNode(graph, position)
+	local mergeDistance = graph.mergeDistance
+	if mergeDistance > 0 then
+		for _, nodeId in ipairs(RoadGraph.getNearbyNodeIds(graph, position, mergeDistance)) do
+			local node = graph.nodes[nodeId]
+			if node
+				and math.abs(node.position.Y - position.Y) <= graph.maxMergeHeight
+				and RoadSampling.distanceXZ(node.position, position) <= mergeDistance
+			then
+				return nodeId
+			end
+		end
+	end
+
+	local nodeId = #graph.nodes + 1
+	graph.nodes[nodeId] = {
+		position = position,
+		neighbors = {},
+	}
+
+	local ix = math.floor(position.X / graph.bucketSize)
+	local iz = math.floor(position.Z / graph.bucketSize)
+	local key = getBucketKey(ix, iz)
+	local bucket = graph.nodeBuckets[key]
+	if not bucket then
+		bucket = {}
+		graph.nodeBuckets[key] = bucket
+	end
+	table.insert(bucket, nodeId)
+
+	return nodeId
+end
+
+function RoadGraph.addEdge(graph, a, b)
+	if not a or not b or a == b then
+		return
+	end
+
+	local key = if a < b then tostring(a) .. ":" .. tostring(b) else tostring(b) .. ":" .. tostring(a)
+	if graph.edgeLookup[key] then
+		return
+	end
+
+	local aPosition = graph.nodes[a].position
+	local bPosition = graph.nodes[b].position
+	local cost = RoadSampling.distanceXZ(aPosition, bPosition)
+	if cost <= 0.1 then
+		return
+	end
+
+	graph.edgeLookup[key] = true
+	table.insert(graph.nodes[a].neighbors, { id = b, cost = cost })
+	table.insert(graph.nodes[b].neighbors, { id = a, cost = cost })
+	table.insert(graph.edges, { a = a, b = b, cost = cost })
+end
+
+function RoadGraph.connectJunction(graph, center, radius, extraRadius)
+	local junctionId = RoadGraph.addNode(graph, center)
+	local connectRadius = math.max((tonumber(radius) or 0) + (tonumber(extraRadius) or 0), graph.mergeDistance)
+
+	for _, nodeId in ipairs(RoadGraph.getNearbyNodeIds(graph, center, connectRadius)) do
+		local node = graph.nodes[nodeId]
+		if nodeId ~= junctionId
+			and node
+			and math.abs(node.position.Y - center.Y) <= graph.maxMergeHeight
+			and RoadSampling.distanceXZ(node.position, center) <= connectRadius
+		then
+			RoadGraph.addEdge(graph, junctionId, nodeId)
+		end
+	end
+end
+
+function RoadGraph.addSplineRecords(graph, records)
+	for _, record in ipairs(records) do
+		local firstNodeId = nil
+		local previousNodeId = nil
+
+		for _, position in ipairs(record.positions or {}) do
+			local nodeId = RoadGraph.addNode(graph, position)
+			if not firstNodeId then
+				firstNodeId = nodeId
+			end
+
+			if previousNodeId then
+				RoadGraph.addEdge(graph, previousNodeId, nodeId)
+			end
+
+			previousNodeId = nodeId
+		end
+
+		if firstNodeId and previousNodeId and firstNodeId ~= previousNodeId and record.closed == true then
+			RoadGraph.addEdge(graph, previousNodeId, firstNodeId)
+		end
+	end
+end
+
+function RoadGraph.findNearestEdge(graph, position)
+	if not graph then
+		return nil
+	end
+
+	local best = nil
+	local bestScore = math.huge
+	for _, edge in ipairs(graph.edges) do
+		local a = graph.nodes[edge.a].position
+		local b = graph.nodes[edge.b].position
+		local projected, alpha, distance = RoadSampling.projectPointToSegmentXZ(position, a, b)
+		local verticalPenalty = math.abs(position.Y - projected.Y) * 0.08
+		local score = distance + verticalPenalty
+		if score < bestScore then
+			bestScore = score
+			best = {
+				edge = edge,
+				position = projected,
+				alpha = alpha,
+				distance = distance,
+			}
+		end
+	end
+
+	return best
+end
+
+function RoadGraph.findNearestNode(graph, position)
+	local bestNodeId = nil
+	local bestScore = math.huge
+
+	for nodeId, node in ipairs(graph.nodes) do
+		local score = RoadSampling.distanceXZSquared(position, node.position)
+		if score < bestScore then
+			bestScore = score
+			bestNodeId = nodeId
+		end
+	end
+
+	return bestNodeId
+end
+
+local function addTemporaryConnection(neighbors, a, b, cost)
+	if not a or not b or a == b then
+		return
+	end
+
+	neighbors[a] = neighbors[a] or {}
+	neighbors[b] = neighbors[b] or {}
+	table.insert(neighbors[a], { id = b, cost = cost })
+	table.insert(neighbors[b], { id = a, cost = cost })
+end
+
+local function connectTemporaryNode(graph, neighbors, nodeId, position)
+	local snap = RoadGraph.findNearestEdge(graph, position)
+	if snap then
+		local a = graph.nodes[snap.edge.a].position
+		local b = graph.nodes[snap.edge.b].position
+		addTemporaryConnection(neighbors, nodeId, snap.edge.a, RoadSampling.distanceXZ(snap.position, a))
+		addTemporaryConnection(neighbors, nodeId, snap.edge.b, RoadSampling.distanceXZ(snap.position, b))
+		return snap
+	end
+
+	local nearestNodeId = RoadGraph.findNearestNode(graph, position)
+	if nearestNodeId then
+		addTemporaryConnection(neighbors, nodeId, nearestNodeId, RoadSampling.distanceXZ(position, graph.nodes[nearestNodeId].position))
+	end
+
+	return nil
+end
+
+local function heapPush(heap, item)
+	table.insert(heap, item)
+	local index = #heap
+	while index > 1 do
+		local parent = math.floor(index * 0.5)
+		if heap[parent].cost <= item.cost then
+			break
+		end
+		heap[index] = heap[parent]
+		index = parent
+	end
+	heap[index] = item
+end
+
+local function heapPop(heap)
+	local root = heap[1]
+	if not root then
+		return nil
+	end
+
+	local last = table.remove(heap)
+	if #heap == 0 then
+		return root
+	end
+
+	local index = 1
+	while true do
+		local left = index * 2
+		local right = left + 1
+		if left > #heap then
+			break
+		end
+
+		local child = left
+		if right <= #heap and heap[right].cost < heap[left].cost then
+			child = right
+		end
+
+		if heap[child].cost >= last.cost then
+			break
+		end
+
+		heap[index] = heap[child]
+		index = child
+	end
+
+	heap[index] = last
+	return root
+end
+
+local function getNodePosition(graph, temporaryPositions, nodeId)
+	return temporaryPositions[nodeId] or graph.nodes[nodeId].position
+end
+
+function RoadGraph.findPath(graph, startPosition, targetPosition)
+	if not graph or #graph.nodes == 0 or #graph.edges == 0 then
+		return nil
+	end
+
+	local startId = #graph.nodes + 1
+	local targetId = #graph.nodes + 2
+	local temporaryPositions = {
+		[startId] = startPosition,
+		[targetId] = targetPosition,
+	}
+	local temporaryNeighbors = {}
+	local startSnap = connectTemporaryNode(graph, temporaryNeighbors, startId, startPosition)
+	local targetSnap = connectTemporaryNode(graph, temporaryNeighbors, targetId, targetPosition)
+
+	if startSnap then
+		temporaryPositions[startId] = startSnap.position
+	end
+	if targetSnap then
+		temporaryPositions[targetId] = targetSnap.position
+	end
+	if startSnap and targetSnap and startSnap.edge == targetSnap.edge then
+		addTemporaryConnection(
+			temporaryNeighbors,
+			startId,
+			targetId,
+			RoadSampling.distanceXZ(temporaryPositions[startId], temporaryPositions[targetId])
+		)
+	end
+
+	local distances = {
+		[startId] = 0,
+	}
+	local previous = {}
+	local heap = {}
+	heapPush(heap, { id = startId, cost = 0 })
+
+	local function relax(fromId, neighbor)
+		local nextCost = distances[fromId] + neighbor.cost
+		if not distances[neighbor.id] or nextCost < distances[neighbor.id] then
+			distances[neighbor.id] = nextCost
+			previous[neighbor.id] = fromId
+			heapPush(heap, { id = neighbor.id, cost = nextCost })
+		end
+	end
+
+	while #heap > 0 do
+		local current = heapPop(heap)
+		if current and current.cost == distances[current.id] then
+			if current.id == targetId then
+				break
+			end
+
+			if current.id <= #graph.nodes then
+				for _, neighbor in ipairs(graph.nodes[current.id].neighbors) do
+					relax(current.id, neighbor)
+				end
+			end
+
+			for _, neighbor in ipairs(temporaryNeighbors[current.id] or {}) do
+				relax(current.id, neighbor)
+			end
+		end
+	end
+
+	if not distances[targetId] then
+		return nil
+	end
+
+	local reversed = {}
+	local nodeId = targetId
+	while nodeId do
+		table.insert(reversed, getNodePosition(graph, temporaryPositions, nodeId))
+		nodeId = previous[nodeId]
+	end
+
+	local path = {}
+	for i = #reversed, 1, -1 do
+		table.insert(path, reversed[i])
+	end
+
+	return path
+end
+
+return RoadGraph

--- a/src/shared/RoadSampling.lua
+++ b/src/shared/RoadSampling.lua
@@ -1,0 +1,221 @@
+local RoadSampling = {}
+
+RoadSampling.DEFAULT_ROAD_WIDTH = 28
+RoadSampling.MIN_ROAD_WIDTH = 8
+RoadSampling.MAX_ROAD_WIDTH = 200
+RoadSampling.ROAD_WIDTH_ATTR = "RoadWidth"
+
+function RoadSampling.sanitizeRoadWidth(value, defaultWidth)
+	local fallback = tonumber(defaultWidth) or RoadSampling.DEFAULT_ROAD_WIDTH
+	local width = tonumber(value) or fallback
+	return math.clamp(width, RoadSampling.MIN_ROAD_WIDTH, RoadSampling.MAX_ROAD_WIDTH)
+end
+
+function RoadSampling.getConfiguredRoadWidth(config)
+	local configuredDefault = config and tonumber(config.authoredRoadCollisionWidth)
+	return RoadSampling.sanitizeRoadWidth(configuredDefault, RoadSampling.DEFAULT_ROAD_WIDTH)
+end
+
+function RoadSampling.getSplineRoadWidth(spline, defaultWidth)
+	local configuredDefault = RoadSampling.sanitizeRoadWidth(defaultWidth, RoadSampling.DEFAULT_ROAD_WIDTH)
+	local attrValue = spline and spline:GetAttribute(RoadSampling.ROAD_WIDTH_ATTR)
+	return RoadSampling.sanitizeRoadWidth(attrValue, configuredDefault)
+end
+
+function RoadSampling.distanceXZ(a, b)
+	local dx = a.X - b.X
+	local dz = a.Z - b.Z
+	return math.sqrt(dx * dx + dz * dz)
+end
+
+function RoadSampling.distanceXZSquared(a, b)
+	local dx = a.X - b.X
+	local dz = a.Z - b.Z
+	return dx * dx + dz * dz
+end
+
+function RoadSampling.horizontalUnit(vector)
+	local flat = Vector3.new(vector.X, 0, vector.Z)
+	if flat.Magnitude < 1e-4 then
+		return nil
+	end
+	return flat.Unit
+end
+
+function RoadSampling.catmullRom(p0, p1, p2, p3, t)
+	local t2 = t * t
+	local t3 = t2 * t
+	return 0.5 * ((2 * p1) + (-p0 + p2) * t + (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 + (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
+end
+
+function RoadSampling.samplePositions(positions, closedCurve, sampleStep)
+	if #positions < 2 then
+		local copy = {}
+		for _, position in ipairs(positions) do
+			table.insert(copy, position)
+		end
+		return copy
+	end
+
+	if closedCurve and #positions < 3 then
+		closedCurve = false
+	end
+
+	local samples = {}
+	sampleStep = math.max(tonumber(sampleStep) or 8, 1)
+	if closedCurve then
+		local count = #positions
+		for i = 1, count do
+			local p0 = positions[((i - 2) % count) + 1]
+			local p1 = positions[i]
+			local p2 = positions[(i % count) + 1]
+			local p3 = positions[((i + 1) % count) + 1]
+			local segmentLen = (p2 - p1).Magnitude
+			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
+
+			for s = 0, subdivisions - 1 do
+				table.insert(samples, RoadSampling.catmullRom(p0, p1, p2, p3, s / subdivisions))
+			end
+		end
+
+		if #samples > 1 then
+			table.insert(samples, samples[1])
+		end
+	else
+		for i = 1, #positions - 1 do
+			local p0 = positions[math.max(1, i - 1)]
+			local p1 = positions[i]
+			local p2 = positions[i + 1]
+			local p3 = positions[math.min(#positions, i + 2)]
+			local segmentLen = (p2 - p1).Magnitude
+			local subdivisions = math.max(2, math.floor(segmentLen / sampleStep))
+
+			for s = 0, subdivisions - 1 do
+				table.insert(samples, RoadSampling.catmullRom(p0, p1, p2, p3, s / subdivisions))
+			end
+		end
+
+		table.insert(samples, positions[#positions])
+	end
+
+	return samples
+end
+
+function RoadSampling.sampleLoopIsClosed(samples)
+	if #samples < 3 then
+		return false
+	end
+	return RoadSampling.distanceXZ(samples[1], samples[#samples]) <= 0.05 and math.abs(samples[1].Y - samples[#samples].Y) <= 0.05
+end
+
+function RoadSampling.getRoadSampleTangent(samples, index, edgeCount, closedLoop, fallbackDir)
+	if closedLoop then
+		local prevIndex = index - 1
+		if prevIndex < 1 then
+			prevIndex = edgeCount
+		end
+		local nextIndex = index + 1
+		if nextIndex > edgeCount then
+			nextIndex = 1
+		end
+		local prevDir = RoadSampling.horizontalUnit(samples[index] - samples[prevIndex])
+		local nextDir = RoadSampling.horizontalUnit(samples[nextIndex] - samples[index])
+		if prevDir and nextDir then
+			local combined = prevDir + nextDir
+			if combined.Magnitude > 1e-4 then
+				return combined.Unit
+			end
+		end
+		return nextDir or prevDir or fallbackDir
+	end
+
+	if index == 1 then
+		return RoadSampling.horizontalUnit(samples[2] - samples[1]) or fallbackDir
+	elseif index == edgeCount then
+		return RoadSampling.horizontalUnit(samples[edgeCount] - samples[edgeCount - 1]) or fallbackDir
+	end
+
+	local prevDir = RoadSampling.horizontalUnit(samples[index] - samples[index - 1])
+	local nextDir = RoadSampling.horizontalUnit(samples[index + 1] - samples[index])
+	if prevDir and nextDir then
+		local combined = prevDir + nextDir
+		if combined.Magnitude > 1e-4 then
+			return combined.Unit
+		end
+	end
+	return nextDir or prevDir or fallbackDir
+end
+
+function RoadSampling.polylineLength(points, closedLoop)
+	local count = #points
+	if count < 2 then
+		return 0
+	end
+
+	local segmentCount = closedLoop and count or count - 1
+	local total = 0
+	for i = 1, segmentCount do
+		local nextIndex = closedLoop and ((i % count) + 1) or (i + 1)
+		total += (points[nextIndex] - points[i]).Magnitude
+	end
+	return total
+end
+
+function RoadSampling.samplePolylineAtFraction(points, closedLoop, fraction)
+	local count = #points
+	if count == 0 then
+		return Vector3.zero
+	elseif count == 1 then
+		return points[1]
+	end
+
+	local totalLength = RoadSampling.polylineLength(points, closedLoop)
+	if totalLength <= 1e-4 then
+		return points[1]
+	end
+
+	local target = math.clamp(fraction, 0, 1) * totalLength
+	if closedLoop then
+		target = target % totalLength
+	elseif target <= 0 then
+		return points[1]
+	elseif target >= totalLength then
+		return points[count]
+	end
+
+	local traveled = 0
+	local segmentCount = closedLoop and count or count - 1
+	for i = 1, segmentCount do
+		local nextIndex = closedLoop and ((i % count) + 1) or (i + 1)
+		local a = points[i]
+		local b = points[nextIndex]
+		local segmentLength = (b - a).Magnitude
+		if segmentLength > 1e-4 then
+			if traveled + segmentLength >= target then
+				return a:Lerp(b, (target - traveled) / segmentLength)
+			end
+			traveled += segmentLength
+		end
+	end
+
+	return closedLoop and points[1] or points[count]
+end
+
+function RoadSampling.projectPointToSegmentXZ(position, a, b)
+	local dx = b.X - a.X
+	local dz = b.Z - a.Z
+	local lengthSquared = dx * dx + dz * dz
+	if lengthSquared <= 0.001 then
+		return a, 0, RoadSampling.distanceXZ(position, a)
+	end
+
+	local alpha = math.clamp(((position.X - a.X) * dx + (position.Z - a.Z) * dz) / lengthSquared, 0, 1)
+	local projected = Vector3.new(
+		a.X + dx * alpha,
+		a.Y + (b.Y - a.Y) * alpha,
+		a.Z + dz * alpha
+	)
+	return projected, alpha, RoadSampling.distanceXZ(position, projected)
+end
+
+return RoadSampling

--- a/src/shared/RoadSplineData.lua
+++ b/src/shared/RoadSplineData.lua
@@ -1,0 +1,178 @@
+local RoadSampling = require(script.Parent:WaitForChild("RoadSampling"))
+
+local RoadSplineData = {}
+
+RoadSplineData.EDITOR_ROOT_NAME = "Cab87RoadEditor"
+RoadSplineData.SPLINES_NAME = "Splines"
+RoadSplineData.POINTS_NAME = "RoadPoints"
+RoadSplineData.NETWORK_NAME = "RoadNetwork"
+RoadSplineData.WIREFRAME_NAME = "WireframeDisplay"
+RoadSplineData.RUNTIME_DATA_NAME = "AuthoredRoadSplineData"
+RoadSplineData.JUNCTIONS_NAME = "Junctions"
+RoadSplineData.ROAD_WIDTH_ATTR = RoadSampling.ROAD_WIDTH_ATTR
+
+function RoadSplineData.sortedChildren(parent, className)
+	local children = {}
+	if not parent then
+		return children
+	end
+
+	for _, child in ipairs(parent:GetChildren()) do
+		if not className or child:IsA(className) then
+			table.insert(children, child)
+		end
+	end
+
+	table.sort(children, function(a, b)
+		return a.Name < b.Name
+	end)
+
+	return children
+end
+
+function RoadSplineData.getDataRoot(world)
+	return world and world:FindFirstChild(RoadSplineData.RUNTIME_DATA_NAME)
+end
+
+function RoadSplineData.getSplines(root)
+	local splinesFolder = root and root:FindFirstChild(RoadSplineData.SPLINES_NAME)
+	if splinesFolder and splinesFolder:IsA("Folder") then
+		return RoadSplineData.sortedChildren(splinesFolder, "Model")
+	end
+
+	local legacyPoints = root and root:FindFirstChild(RoadSplineData.POINTS_NAME)
+	if legacyPoints and legacyPoints:IsA("Folder") then
+		return { root }
+	end
+
+	return {}
+end
+
+function RoadSplineData.getSplinePoints(spline)
+	local pointsFolder = spline and spline:FindFirstChild(RoadSplineData.POINTS_NAME)
+	if not (pointsFolder and pointsFolder:IsA("Folder")) then
+		return {}
+	end
+
+	local points = {}
+	for _, child in ipairs(pointsFolder:GetChildren()) do
+		if child:IsA("BasePart") or child:IsA("Vector3Value") then
+			table.insert(points, child)
+		end
+	end
+
+	table.sort(points, function(a, b)
+		return a.Name < b.Name
+	end)
+
+	return points
+end
+
+function RoadSplineData.getPointPosition(point)
+	if not point then
+		return nil
+	end
+
+	if point:IsA("BasePart") then
+		return point.Position
+	elseif point:IsA("Vector3Value") then
+		return point.Value
+	end
+
+	return nil
+end
+
+function RoadSplineData.getPointPositions(points)
+	local positions = {}
+	for _, point in ipairs(points) do
+		local position = RoadSplineData.getPointPosition(point)
+		if position then
+			table.insert(positions, position)
+		end
+	end
+	return positions
+end
+
+function RoadSplineData.collectSplineRecords(root, options)
+	options = options or {}
+	local defaultWidth = options.defaultRoadWidth
+	local minPoints = options.minPoints or 2
+	local records = {}
+
+	for _, spline in ipairs(RoadSplineData.getSplines(root)) do
+		local points = RoadSplineData.getSplinePoints(spline)
+		local positions = RoadSplineData.getPointPositions(points)
+		if #positions >= minPoints then
+			table.insert(records, {
+				spline = spline,
+				name = spline.Name,
+				points = points,
+				positions = positions,
+				closed = spline:GetAttribute("ClosedCurve") == true,
+				sampled = spline:GetAttribute("SampledRoadChain") == true,
+				width = RoadSampling.getSplineRoadWidth(spline, defaultWidth),
+				componentId = tonumber(spline:GetAttribute("ComponentId")) or 1,
+			})
+		end
+	end
+
+	return records
+end
+
+function RoadSplineData.collectSampledChains(root, options)
+	options = options or {}
+	local sampleStep = options.sampleStep or 8
+	local preserveSampledChains = options.preserveSampledChains ~= false
+	local chains = {}
+
+	for _, record in ipairs(RoadSplineData.collectSplineRecords(root, options)) do
+		local samples
+		if preserveSampledChains and record.sampled then
+			samples = {}
+			for _, position in ipairs(record.positions) do
+				table.insert(samples, position)
+			end
+		else
+			samples = RoadSampling.samplePositions(record.positions, record.closed, sampleStep)
+		end
+
+		table.insert(chains, {
+			spline = record.spline,
+			name = record.name,
+			points = record.points,
+			positions = record.positions,
+			samples = samples,
+			closed = record.closed,
+			sampled = record.sampled,
+			width = record.width,
+			componentId = record.componentId,
+		})
+	end
+
+	return chains
+end
+
+function RoadSplineData.collectJunctions(root, options)
+	options = options or {}
+	local junctionsFolder = root and root:FindFirstChild(RoadSplineData.JUNCTIONS_NAME)
+	if not (junctionsFolder and junctionsFolder:IsA("Folder")) then
+		return {}
+	end
+
+	local defaultRadius = tonumber(options.defaultRadius) or RoadSampling.DEFAULT_ROAD_WIDTH * 0.5
+	local minRadius = tonumber(options.minRadius) or 0
+	local junctions = {}
+	for _, junctionData in ipairs(RoadSplineData.sortedChildren(junctionsFolder, "Vector3Value")) do
+		local radius = math.max(tonumber(junctionData:GetAttribute("Radius")) or defaultRadius, minRadius)
+		table.insert(junctions, {
+			center = junctionData.Value,
+			radius = radius,
+			componentId = tonumber(junctionData:GetAttribute("ComponentId")) or 1,
+			members = {},
+			chains = {},
+		})
+	end
+	return junctions
+end
+
+return RoadSplineData


### PR DESCRIPTION
## Summary
- add shared RoadSplineData, RoadSampling, and RoadGraph modules for authored-road parsing, sampling, width/distance helpers, and route graph pathfinding
- update server road runtime, client road visuals, GPS, minimap, and passenger stop placement to use the shared helpers
- keep mesh creation, UI rendering, and runtime Instance construction in server/client systems

## Validation
- rojo build default.project.json --output cab87.rbxlx
- git diff --check

Closes #16