### PR TITLE
[codex] Centralize remote name lookups

### DIFF
--- a/src/client/CameraController.client.lua
+++ b/src/client/CameraController.client.lua
@@ -324,8 +324,7 @@ local function updateActiveCamera(dt)
 end
 
 task.spawn(function()
-	local cameraEventRemoteName = Remotes.serverToClient and Remotes.serverToClient.cameraEvent
-		or "Cab87CameraEvent"
+	local cameraEventRemoteName = Remotes.getServerToClientName("cameraEvent")
 	local cameraEventRemote = ReplicatedStorage:WaitForChild(cameraEventRemoteName, 10)
 	if cameraEventRemote and cameraEventRemote:IsA("RemoteEvent") then
 		cameraEventRemote.OnClientEvent:Connect(function(action, intensity)

--- a/src/client/Controllers/DebugTuningPanel.lua
+++ b/src/client/Controllers/DebugTuningPanel.lua
@@ -103,8 +103,7 @@ function DebugTuningPanel.start(parentGui)
 		return nil
 	end
 
-	local debugTuneRemoteName = Remotes.clientToServer and Remotes.clientToServer.debugTune
-		or "Cab87DebugTune"
+	local debugTuneRemoteName = Remotes.getClientToServerName("debugTune")
 	local debugTuneRemote = ReplicatedStorage:WaitForChild(debugTuneRemoteName, 10)
 	if not debugTuneRemote or not debugTuneRemote:IsA("RemoteEvent") then
 		return nil

--- a/src/client/Controllers/InputController.lua
+++ b/src/client/Controllers/InputController.lua
@@ -54,8 +54,7 @@ function InputController.start()
 		forceSendAccumulator = 0,
 	}
 
-	local driveInputRemoteName = Remotes.clientToServer and Remotes.clientToServer.driveInput
-		or "Cab87DriveInput"
+	local driveInputRemoteName = Remotes.getClientToServerName("driveInput")
 	local driveInputRemote = ReplicatedStorage:WaitForChild(driveInputRemoteName)
 
 	local function connect(signal, callback)

--- a/src/client/GameplayStateStore.lua
+++ b/src/client/GameplayStateStore.lua
@@ -7,8 +7,7 @@ local StateContracts = require(shared:WaitForChild("StateContracts"))
 
 local GameplayStateStore = {}
 
-local remoteName = Remotes.serverToClient and Remotes.serverToClient.gameplayStateUpdated
-	or "Cab87GameplayStateUpdated"
+local remoteName = Remotes.getServerToClientName("gameplayStateUpdated")
 local remote = ReplicatedStorage:WaitForChild(remoteName)
 local cabIdAttribute = Config.gameplayStateCabIdAttribute or "Cab87GameplayCabId"
 local actions = StateContracts.actions

--- a/src/server/Runtime/RemoteRegistry.lua
+++ b/src/server/Runtime/RemoteRegistry.lua
@@ -3,14 +3,6 @@ local RunService = game:GetService("RunService")
 
 local RemoteRegistry = {}
 
-local DEFAULT_REMOTE_NAMES = {
-	driveInput = "Cab87DriveInput",
-	cameraEvent = "Cab87CameraEvent",
-	debugTune = "Cab87DebugTune",
-	gameplayStateUpdated = "Cab87GameplayStateUpdated",
-	shiftStateUpdated = "Cab87ShiftStateUpdated",
-}
-
 local function loadSharedModule(moduleName)
 	local shared = ReplicatedStorage:FindFirstChild("Shared")
 	local module = shared and shared:FindFirstChild(moduleName)
@@ -28,16 +20,17 @@ local function loadSharedModule(moduleName)
 end
 
 local function getRemoteNames()
-	local Remotes = loadSharedModule("Remotes") or {}
-	local serverToClient = Remotes.serverToClient or {}
-	local clientToServer = Remotes.clientToServer or {}
+	local Remotes = loadSharedModule("Remotes")
+	if type(Remotes) ~= "table" then
+		error("[cab87] Remotes module is required to register remote events")
+	end
 
 	return {
-		driveInput = clientToServer.driveInput or DEFAULT_REMOTE_NAMES.driveInput,
-		cameraEvent = serverToClient.cameraEvent or DEFAULT_REMOTE_NAMES.cameraEvent,
-		debugTune = clientToServer.debugTune or DEFAULT_REMOTE_NAMES.debugTune,
-		gameplayStateUpdated = serverToClient.gameplayStateUpdated or DEFAULT_REMOTE_NAMES.gameplayStateUpdated,
-		shiftStateUpdated = serverToClient.shiftStateUpdated or DEFAULT_REMOTE_NAMES.shiftStateUpdated,
+		driveInput = Remotes.getClientToServerName("driveInput"),
+		cameraEvent = Remotes.getServerToClientName("cameraEvent"),
+		debugTune = Remotes.getClientToServerName("debugTune"),
+		gameplayStateUpdated = Remotes.getServerToClientName("gameplayStateUpdated"),
+		shiftStateUpdated = Remotes.getServerToClientName("shiftStateUpdated"),
 	}
 end
 

--- a/src/shared/Remotes.lua
+++ b/src/shared/Remotes.lua
@@ -21,4 +21,26 @@ local Remotes = {
 	},
 }
 
+local function getRemoteName(groupName, remoteKey)
+	local group = Remotes[groupName]
+	if type(group) ~= "table" then
+		error(("[cab87] Remotes.%s must be a table"):format(groupName), 3)
+	end
+
+	local remoteName = group[remoteKey]
+	if type(remoteName) ~= "string" or remoteName == "" then
+		error(("[cab87] Remotes.%s.%s must be a non-empty string"):format(groupName, tostring(remoteKey)), 3)
+	end
+
+	return remoteName
+end
+
+function Remotes.getClientToServerName(remoteKey)
+	return getRemoteName("clientToServer", remoteKey)
+end
+
+function Remotes.getServerToClientName(remoteKey)
+	return getRemoteName("serverToClient", remoteKey)
+end
+
 return Remotes


### PR DESCRIPTION
## Summary

- Add shared remote-name accessors to `src/shared/Remotes.lua`.
- Remove duplicate concrete remote fallback strings from `RemoteRegistry`.
- Update client controllers and gameplay state code to resolve remote names through `Remotes.lua`.

## Impact

This makes `Remotes.lua` the sole source of truth for the concrete remote names used by driving input, camera feedback, debug tuning, gameplay state, and shift state remotes.

Closes #46.

## Validation

- `rokit install`
- `git diff --check`
- `rojo build default.project.json --output cab87.rbxlx`
- `rg -n "Cab87DriveInput|Cab87CameraEvent|Cab87DebugTune|Cab87GameplayStateUpdated|Cab87ShiftStateUpdated" .`

Studio Play smoke testing was not run from this terminal session.