### PR TITLE
[codex] Complete owner-aware taxi registry

### DIFF
--- a/src/server/Controllers/TaxiController.lua
+++ b/src/server/Controllers/TaxiController.lua
@@ -26,6 +26,27 @@ local function moveAngleToward(fromAngle, toAngle, maxDelta)
 	return fromAngle + math.clamp(delta, -maxDelta, maxDelta)
 end
 
+local function getOwnerUserId(owner)
+	if typeof(owner) == "Instance" and owner:IsA("Player") then
+		return owner.UserId
+	end
+
+	if type(owner) == "number" and owner == owner and owner > 0 then
+		return math.floor(owner)
+	end
+
+	return nil
+end
+
+local function getOwnerAttributeName(config)
+	local attributeName = config and config.carOwnerUserIdAttribute
+	if type(attributeName) == "string" and attributeName ~= "" then
+		return attributeName
+	end
+
+	return "Cab87OwnerUserId"
+end
+
 local TaxiController = {}
 TaxiController.__index = TaxiController
 
@@ -46,6 +67,7 @@ function TaxiController.new(options)
 		fareService = options.fareService,
 		ownerPlayer = options.ownerPlayer,
 		ownerUserId = options.ownerUserId,
+		ownerChanged = options.ownerChanged,
 		connections = {},
 		started = false,
 		_playerInputHandler = nil,
@@ -55,6 +77,40 @@ end
 
 function TaxiController:setFareService(fareService)
 	self.fareService = fareService
+end
+
+function TaxiController:_writeOwnerAttribute()
+	if not self.car then
+		return
+	end
+
+	self.car:SetAttribute(getOwnerAttributeName(self.config), self.ownerUserId)
+end
+
+function TaxiController:setOwner(ownerPlayer, ownerUserId, options)
+	options = options or {}
+	local resolvedUserId = getOwnerUserId(ownerPlayer) or getOwnerUserId(ownerUserId)
+	local previousUserId = self.ownerUserId
+	local resolvedPlayer = nil
+	if resolvedUserId then
+		if typeof(ownerPlayer) == "Instance" and ownerPlayer:IsA("Player") and ownerPlayer.UserId == resolvedUserId then
+			resolvedPlayer = ownerPlayer
+		else
+			resolvedPlayer = Players:GetPlayerByUserId(resolvedUserId)
+		end
+	end
+
+	self.ownerPlayer = resolvedPlayer
+	self.ownerUserId = resolvedUserId
+	self:_writeOwnerAttribute()
+
+	if options.notify ~= false and previousUserId ~= resolvedUserId and self.ownerChanged then
+		self.ownerChanged(self, resolvedPlayer, resolvedUserId, previousUserId)
+	end
+end
+
+function TaxiController:clearOwner(options)
+	self:setOwner(nil, nil, options)
 end
 
 function TaxiController:handleDriveInput(player, ...)
@@ -94,9 +150,10 @@ function TaxiController:start()
 	local Config = self.config
 	local driverMode = self.driverMode or Config.driverMode or "Player"
 	local inputProvider = self.inputProvider
-	local ownerUserId = self.ownerUserId
-	if not ownerUserId and self.ownerPlayer and self.ownerPlayer:IsA("Player") then
-		ownerUserId = self.ownerPlayer.UserId
+	if not self.ownerUserId and typeof(self.ownerPlayer) == "Instance" and self.ownerPlayer:IsA("Player") then
+		self:setOwner(self.ownerPlayer, nil)
+	else
+		self:_writeOwnerAttribute()
 	end
 
 	local defaultSpawnPose = spawnPose or {
@@ -300,6 +357,7 @@ function TaxiController:start()
 	end
 
 	local function handlePlayerDriveInput(player, action, throttle, steer, drift, airPitch)
+		local ownerUserId = self.ownerUserId
 		if ownerUserId and player.UserId ~= ownerUserId then
 			return
 		end
@@ -353,11 +411,10 @@ function TaxiController:start()
 	trackConnection(seat:GetPropertyChangedSignal("Occupant"):Connect(function()
 		local occupant = seat.Occupant
 		if occupant then
-			if not ownerUserId then
+			if not self.ownerUserId then
 				local ownerPlayer = Players:GetPlayerFromCharacter(occupant.Parent)
 				if ownerPlayer then
-					ownerUserId = ownerPlayer.UserId
-					self.ownerUserId = ownerUserId
+					self:setOwner(ownerPlayer, nil)
 				end
 			end
 
@@ -365,6 +422,18 @@ function TaxiController:start()
 		else
 			driverInput = {}
 			restoreHiddenCharacter()
+		end
+	end))
+
+	trackConnection(Players.PlayerRemoving:Connect(function(player)
+		driverInput[player] = nil
+		local character = player.Character
+		local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+		if humanoid and humanoid == seat.Occupant then
+			restoreHiddenCharacter()
+		end
+		if self.ownerUserId == player.UserId then
+			self:clearOwner()
 		end
 	end))
 

--- a/src/server/Main.server.lua
+++ b/src/server/Main.server.lua
@@ -223,12 +223,20 @@ local function bootstrap()
 	end)
 	debugTuningService:start()
 
-	local playerCab = taxiService:createCab({
-		world = world,
-		spawnPose = spawnPose,
-		profileName = Config.carDefaultProfileName,
-		ownerPlayer = Players:GetPlayers()[1],
-	})
+	local initialPlayer = Players:GetPlayers()[1]
+	local playerCab = nil
+	if initialPlayer then
+		playerCab = taxiService:spawnCabForPlayer(initialPlayer, Config.carDefaultProfileName, spawnPose, {
+			world = world,
+			startController = false,
+		})
+	else
+		playerCab = taxiService:createCab({
+			world = world,
+			spawnPose = spawnPose,
+			profileName = Config.carDefaultProfileName,
+		})
+	end
 	local car = playerCab.car
 	local gpsService = GpsService.start({
 		world = world,
@@ -240,6 +248,7 @@ local function bootstrap()
 		config = Config,
 		car = car,
 		shiftService = shiftService,
+		ownerUserId = playerCab.ownerUserId,
 	})
 	if shiftService and shiftService.onPhaseChanged then
 		shiftService:onPhaseChanged(function(snapshot)
@@ -254,6 +263,7 @@ local function bootstrap()
 		driverMode = "Player",
 		fareService = fareService,
 		ownerPlayer = playerCab.ownerPlayer,
+		ownerUserId = playerCab.ownerUserId,
 	})
 
 	passengerService = PassengerService.start({

--- a/src/server/PassengerService.lua
+++ b/src/server/PassengerService.lua
@@ -320,9 +320,27 @@ local function getCabDoorPosition(car)
 	return pivot:PointToWorldSpace(Vector3.new(-6.3, -rideHeight + 0.15, 0.8))
 end
 
-local function getCabOwnerPlayer(car)
+local function getCabOwnerUserId(car)
 	if not car then
 		return nil
+	end
+
+	local value = car:GetAttribute(getConfigString("carOwnerUserIdAttribute", "Cab87OwnerUserId"))
+	if type(value) == "number" and value == value and value > 0 then
+		return math.floor(value)
+	end
+
+	return nil
+end
+
+local function getCabFareOwner(car)
+	if not car then
+		return nil
+	end
+
+	local ownerUserId = getCabOwnerUserId(car)
+	if ownerUserId then
+		return ownerUserId
 	end
 
 	local seat = car:FindFirstChild("DriverSeat")
@@ -694,7 +712,7 @@ local function completeBoarding(service, passenger)
 	service.pickupCooldown = getConfigNumber("passengerModeSwitchCooldown", 0.45)
 	if service.fareService and service.fareService.beginFare then
 		local routeDistance = horizontalDistance(passenger.pickupStop.position, passenger.targetStop.position)
-		service.fareService:beginFare(routeDistance, getCabOwnerPlayer(service.car))
+		service.fareService:beginFare(routeDistance, getCabFareOwner(service.car))
 	end
 	removeWaitingPassengersNearStop(service, passenger.targetStop)
 	PassengerVisuals.setPassengerVisible(passenger.visual, false)

--- a/src/server/Services/FareService.lua
+++ b/src/server/Services/FareService.lua
@@ -23,9 +23,28 @@ local function getOwnerUserId(owner)
 	return nil
 end
 
+local function getConfigString(config, key, fallback)
+	local value = config and config[key]
+	if type(value) == "string" and value ~= "" then
+		return value
+	end
+
+	return fallback
+end
+
+local function getCabOwnerUserId(config, car)
+	if not car then
+		return nil
+	end
+
+	return getOwnerUserId(car:GetAttribute(getConfigString(config, "carOwnerUserIdAttribute", "Cab87OwnerUserId")))
+end
+
 function FareService.new(options)
 	options = options or {}
-	local ownerUserId = getOwnerUserId(options.ownerPlayer) or getOwnerUserId(options.ownerUserId)
+	local ownerUserId = getCabOwnerUserId(options.config, options.car)
+		or getOwnerUserId(options.ownerPlayer)
+		or getOwnerUserId(options.ownerUserId)
 
 	return setmetatable({
 		config = options.config or {},
@@ -56,11 +75,14 @@ function FareService:setOwnerPlayer(player)
 	self.ownerUserId = getOwnerUserId(player)
 end
 
+function FareService:setOwnerUserId(ownerUserId)
+	self.ownerUserId = getOwnerUserId(ownerUserId)
+end
+
 function FareService:_getOwnerPlayer(ownerUserId)
-	local userId = ownerUserId
-	if userId == nil then
-		userId = self.ownerUserId
-	end
+	local userId = getOwnerUserId(ownerUserId)
+		or getCabOwnerUserId(self.config, self.car)
+		or self.ownerUserId
 
 	if type(userId) == "number" and userId > 0 then
 		return Players:GetPlayerByUserId(userId)
@@ -197,7 +219,9 @@ function FareService:_setLastResult(result)
 end
 
 function FareService:beginFare(routeDistance, ownerPlayer)
-	local ownerUserId = getOwnerUserId(ownerPlayer)
+	local ownerUserId = getCabOwnerUserId(self.config, self.car)
+		or getOwnerUserId(ownerPlayer)
+		or self.ownerUserId
 	self.ownerUserId = ownerUserId
 
 	local estimate = FareRules.buildEstimate(self.config, routeDistance)

--- a/src/server/Services/TaxiService.lua
+++ b/src/server/Services/TaxiService.lua
@@ -1,28 +1,186 @@
+local Players = game:GetService("Players")
+
 local TaxiController = require(script.Parent.Parent:WaitForChild("Controllers"):WaitForChild("TaxiController"))
+
+local OWNER_USER_ID_ATTRIBUTE_FALLBACK = "Cab87OwnerUserId"
 
 local TaxiService = {}
 TaxiService.__index = TaxiService
+
+local function getOwnerUserId(owner)
+	if typeof(owner) == "Instance" and owner:IsA("Player") then
+		return owner.UserId
+	end
+
+	if type(owner) == "number" and owner == owner and owner > 0 then
+		return math.floor(owner)
+	end
+
+	return nil
+end
+
+local function getOwnerAttributeName(config)
+	local attributeName = config and config.carOwnerUserIdAttribute
+	if type(attributeName) == "string" and attributeName ~= "" then
+		return attributeName
+	end
+
+	return OWNER_USER_ID_ATTRIBUTE_FALLBACK
+end
+
+local function getPlayerForUserId(players, ownerPlayer, ownerUserId)
+	if typeof(ownerPlayer) == "Instance" and ownerPlayer:IsA("Player") and ownerPlayer.UserId == ownerUserId then
+		return ownerPlayer
+	end
+
+	if ownerUserId and players and players.GetPlayerByUserId then
+		return players:GetPlayerByUserId(ownerUserId)
+	end
+
+	return nil
+end
 
 function TaxiService.new(options)
 	options = options or {}
 
 	return setmetatable({
 		config = options.config or {},
+		players = options.players or Players,
 		cabFactory = options.cabFactory,
 		remotes = options.remotes or {},
 		world = options.world,
 		driveSurfaces = options.driveSurfaces or {},
 		crashObstacles = options.crashObstacles or {},
 		cabHandles = {},
+		activeCabsByUserId = {},
+		handleByCar = {},
 		controllersBySeat = {},
 		connections = {},
 		started = false,
+		cleanupOwnedCabsOnPlayerRemoving = options.cleanupOwnedCabsOnPlayerRemoving ~= false,
+		destroyOwnedCabsOnPlayerRemoving = options.destroyOwnedCabsOnPlayerRemoving == true,
+		stopReleasedControllersOnPlayerRemoving = options.stopReleasedControllersOnPlayerRemoving == true,
 	}, TaxiService)
 end
 
 function TaxiService:_trackConnection(connection)
 	table.insert(self.connections, connection)
 	return connection
+end
+
+function TaxiService:_trackHandleConnection(handle, connection)
+	handle.connections = handle.connections or {}
+	table.insert(handle.connections, connection)
+	return connection
+end
+
+function TaxiService:_disconnectHandleConnections(handle)
+	for _, connection in ipairs(handle.connections or {}) do
+		connection:Disconnect()
+	end
+	if handle.connections then
+		table.clear(handle.connections)
+	end
+end
+
+function TaxiService:_isHandleActive(handle)
+	return handle ~= nil and handle.car ~= nil and handle.car.Parent ~= nil
+end
+
+function TaxiService:_setCabOwnerAttribute(handle, ownerUserId)
+	if handle and handle.car then
+		handle.car:SetAttribute(getOwnerAttributeName(self.config), ownerUserId)
+	end
+end
+
+function TaxiService:_getActiveCabForUserId(ownerUserId)
+	local resolvedUserId = getOwnerUserId(ownerUserId)
+	if not resolvedUserId then
+		return nil
+	end
+
+	local handle = self.activeCabsByUserId[resolvedUserId]
+	if self:_isHandleActive(handle) then
+		return handle
+	end
+
+	self.activeCabsByUserId[resolvedUserId] = nil
+	return nil
+end
+
+function TaxiService:_removeHandle(handle)
+	if not handle then
+		return
+	end
+
+	if handle.ownerUserId and self.activeCabsByUserId[handle.ownerUserId] == handle then
+		self.activeCabsByUserId[handle.ownerUserId] = nil
+	end
+
+	if handle.car and self.handleByCar[handle.car] == handle then
+		self.handleByCar[handle.car] = nil
+	end
+
+	for index = #self.cabHandles, 1, -1 do
+		if self.cabHandles[index] == handle then
+			table.remove(self.cabHandles, index)
+			break
+		end
+	end
+end
+
+function TaxiService:_setHandleOwner(handle, ownerPlayer, ownerUserId, options)
+	options = options or {}
+	if not handle then
+		return false, nil
+	end
+
+	local resolvedUserId = getOwnerUserId(ownerPlayer) or getOwnerUserId(ownerUserId)
+	if resolvedUserId and not options.allowDuplicate then
+		local existingHandle = self:_getActiveCabForUserId(resolvedUserId)
+		if existingHandle and existingHandle ~= handle then
+			self:_setCabOwnerAttribute(handle, nil)
+			if handle.controller and options.updateController ~= false then
+				handle.controller:clearOwner({
+					notify = false,
+				})
+			end
+			return false, existingHandle
+		end
+	end
+
+	local previousUserId = handle.ownerUserId
+	if previousUserId and previousUserId ~= resolvedUserId and self.activeCabsByUserId[previousUserId] == handle then
+		self.activeCabsByUserId[previousUserId] = nil
+	end
+
+	handle.ownerUserId = resolvedUserId
+	handle.ownerPlayer = if resolvedUserId
+		then getPlayerForUserId(self.players, ownerPlayer, resolvedUserId)
+		else nil
+	self:_setCabOwnerAttribute(handle, resolvedUserId)
+
+	if resolvedUserId and not options.skipRegistry then
+		self.activeCabsByUserId[resolvedUserId] = handle
+	end
+
+	if handle.controller and options.updateController ~= false then
+		handle.controller:setOwner(handle.ownerPlayer, resolvedUserId, {
+			notify = false,
+		})
+	end
+
+	return true, handle
+end
+
+function TaxiService:_clearControllerForHandle(handle)
+	if not handle then
+		return
+	end
+
+	if handle.seat and self.controllersBySeat[handle.seat] == handle.controller then
+		self.controllersBySeat[handle.seat] = nil
+	end
 end
 
 function TaxiService:_getPlayerSeat(player)
@@ -106,32 +264,51 @@ function TaxiService:start()
 			self:_routeDriveInput(player, ...)
 		end))
 	end
+
+	if self.cleanupOwnedCabsOnPlayerRemoving and self.players and self.players.PlayerRemoving then
+		self:_trackConnection(self.players.PlayerRemoving:Connect(function(player)
+			self:releaseCabForPlayer(player, {
+				destroy = self.destroyOwnedCabsOnPlayerRemoving,
+				stopController = self.stopReleasedControllersOnPlayerRemoving,
+			})
+		end))
+	end
 end
 
 function TaxiService:createCab(options)
 	options = options or {}
 
 	local cabFactory = assert(self.cabFactory, "TaxiService requires a cabFactory")
-	local carConfig = options.config or cabFactory:createConfig(options.profileName, options.configOverrides)
+	local profileName = options.profileName or options.taxiId
+	local carConfig = options.config or cabFactory:createConfig(profileName, options.configOverrides)
 	local ownerPlayer = options.ownerPlayer
+	local ownerUserId = getOwnerUserId(ownerPlayer) or getOwnerUserId(options.ownerUserId)
+	if ownerUserId and not options.allowDuplicate and self:_getActiveCabForUserId(ownerUserId) then
+		error("TaxiService already has an active cab for userId " .. tostring(ownerUserId), 2)
+	end
+
 	local resolvedSpawnPose = self:_resolveSpawnPose(options.spawnPose, ownerPlayer, carConfig)
 	local car, seat, driftEmitters = cabFactory:createCab(options.world or self.world, resolvedSpawnPose, carConfig)
 	local handle = {
+		taxiId = options.taxiId or profileName,
 		car = car,
 		seat = seat,
 		driftEmitters = driftEmitters,
 		spawnPose = resolvedSpawnPose,
 		config = carConfig,
-		ownerPlayer = ownerPlayer,
-		ownerUserId = ownerPlayer and ownerPlayer.UserId or options.ownerUserId,
+		ownerPlayer = nil,
+		ownerUserId = nil,
 		controller = nil,
+		connections = {},
 	}
 
-	if type(handle.ownerUserId) == "number" and handle.ownerUserId > 0 then
-		car:SetAttribute("Cab87OwnerUserId", handle.ownerUserId)
-	end
-
+	self.handleByCar[car] = handle
 	table.insert(self.cabHandles, handle)
+	self:_setHandleOwner(handle, ownerPlayer, ownerUserId, {
+		allowDuplicate = options.allowDuplicate,
+		updateController = false,
+	})
+
 	return handle
 end
 
@@ -155,16 +332,39 @@ function TaxiService:startCabController(handle, options)
 		fareService = options.fareService,
 		ownerPlayer = options.ownerPlayer or handle.ownerPlayer,
 		ownerUserId = options.ownerUserId or handle.ownerUserId,
+		ownerChanged = function(_, ownerPlayer, ownerUserId)
+			local ok, existingHandle = self:_setHandleOwner(handle, ownerPlayer, ownerUserId, {
+				updateController = false,
+			})
+			if not ok then
+				warn(
+					string.format(
+						"[cab87] Refused duplicate cab ownership for userId %s; existing cab is %s",
+						tostring(ownerUserId),
+						existingHandle and existingHandle.car and existingHandle.car:GetFullName() or "unknown"
+					)
+				)
+				if handle.controller then
+					handle.controller:clearOwner({
+						notify = false,
+					})
+				end
+			end
+		end,
 	})
 
 	handle.controller = controller
 	self.controllersBySeat[handle.seat] = controller
 	controller:start()
 
-	self:_trackConnection(handle.car.Destroying:Connect(function()
-		if self.controllersBySeat[handle.seat] == controller then
-			self.controllersBySeat[handle.seat] = nil
-		end
+	self:_trackHandleConnection(handle, handle.car.Destroying:Connect(function()
+		self:_clearControllerForHandle(handle)
+		self:_setHandleOwner(handle, nil, nil, {
+			updateController = false,
+		})
+		self:_removeHandle(handle)
+		self:_disconnectHandleConnections(handle)
+		handle.controller = nil
 	end))
 
 	return controller
@@ -177,12 +377,128 @@ function TaxiService:spawnCab(options)
 	return handle
 end
 
+function TaxiService:spawnCabForPlayer(player, taxiId, spawnPose, options)
+	options = options or {}
+	local ownerUserId = getOwnerUserId(player)
+	assert(ownerUserId, "spawnCabForPlayer requires a Player")
+
+	local existingHandle = self:_getActiveCabForUserId(ownerUserId)
+	if existingHandle and not options.allowDuplicate then
+		if options.replaceExisting then
+			self:releaseCab(existingHandle, {
+				destroy = true,
+				stopController = true,
+			})
+		else
+			return existingHandle, false
+		end
+	end
+
+	local cabOptions = table.clone(options)
+	cabOptions.ownerPlayer = player
+	cabOptions.ownerUserId = ownerUserId
+	cabOptions.profileName = taxiId or options.profileName
+	cabOptions.taxiId = taxiId or options.taxiId
+	cabOptions.spawnPose = spawnPose or options.spawnPose
+
+	local handle = self:createCab(cabOptions)
+	if options.startController ~= false then
+		self:startCabController(handle, cabOptions)
+	end
+
+	return handle, true
+end
+
+function TaxiService:recoverCabForPlayer(player, taxiId, spawnPose, options)
+	local cabOptions = table.clone(options or {})
+	cabOptions.replaceExisting = true
+	return self:spawnCabForPlayer(player, taxiId, spawnPose, cabOptions)
+end
+
+function TaxiService:getActiveCabForUserId(ownerUserId)
+	return self:_getActiveCabForUserId(ownerUserId)
+end
+
+function TaxiService:getActiveCabForPlayer(player)
+	return self:_getActiveCabForUserId(getOwnerUserId(player))
+end
+
+function TaxiService:getCabHandleFromCar(car)
+	return self.handleByCar[car]
+end
+
+function TaxiService:getOwnerUserIdForCab(cabOrHandle)
+	if type(cabOrHandle) == "table" and cabOrHandle.car then
+		return cabOrHandle.ownerUserId
+	end
+
+	local handle = self.handleByCar[cabOrHandle]
+	if handle then
+		return handle.ownerUserId
+	end
+
+	if typeof(cabOrHandle) == "Instance" then
+		return getOwnerUserId(cabOrHandle:GetAttribute(getOwnerAttributeName(self.config)))
+	end
+
+	return nil
+end
+
+function TaxiService:releaseCab(handle, options)
+	options = options or {}
+	if not handle then
+		return nil
+	end
+
+	local shouldDestroy = options.destroy == true
+	local shouldStopController = shouldDestroy or options.stopController == true
+
+	self:_setHandleOwner(handle, nil, nil, {
+		updateController = not shouldStopController,
+	})
+
+	if shouldStopController and handle.controller then
+		handle.controller:stop()
+		self:_clearControllerForHandle(handle)
+		handle.controller = nil
+	end
+
+	if shouldDestroy then
+		self:_disconnectHandleConnections(handle)
+		self:_removeHandle(handle)
+		if handle.car and handle.car.Parent then
+			handle.car:Destroy()
+		end
+	end
+
+	return handle
+end
+
+function TaxiService:releaseCabForPlayer(player, options)
+	local handle = self:getActiveCabForPlayer(player)
+	if not handle then
+		return nil
+	end
+
+	return self:releaseCab(handle, options)
+end
+
+function TaxiService:destroyCabForPlayer(player)
+	return self:releaseCabForPlayer(player, {
+		destroy = true,
+		stopController = true,
+	})
+end
+
 function TaxiService:applyLiveTuning(key, value)
 	for index = #self.cabHandles, 1, -1 do
 		local handle = self.cabHandles[index]
 		local car = handle.car
 		if not car or not car.Parent then
-			table.remove(self.cabHandles, index)
+			self:_setHandleOwner(handle, nil, nil, {
+				updateController = false,
+			})
+			self:_removeHandle(handle)
 		else
 			self.cabFactory:applyLiveConfig(car, handle.config, key, value)
 		end
@@ -200,8 +516,15 @@ function TaxiService:stop()
 			handle.controller:stop()
 			handle.controller = nil
 		end
+		self:_disconnectHandleConnections(handle)
+		self:_setHandleOwner(handle, nil, nil, {
+			updateController = false,
+		})
 	end
 	table.clear(self.controllersBySeat)
+	table.clear(self.activeCabsByUserId)
+	table.clear(self.handleByCar)
+	table.clear(self.cabHandles)
 	self.started = false
 end
 

--- a/src/shared/VehicleConfig.lua
+++ b/src/shared/VehicleConfig.lua
@@ -8,6 +8,7 @@ local VehicleConfig = {
 	carDefaultProfileName = "PlayerTaxi",
 	carConfigAttributePrefix = "Cab87CarConfig_",
 	carProfileAttribute = "Cab87CarProfile",
+	carOwnerUserIdAttribute = "Cab87OwnerUserId",
 	carModelAssetId = 75097386419105,
 	carModelAssetScale = 1,
 	carModelAssetYawOffsetDegrees = 0,


### PR DESCRIPTION
## Summary

Closes #44.

- Add an owner-aware active cab registry in `TaxiService`, keyed by user id, with duplicate prevention and lookup helpers.
- Add explicit spawn/recover/release APIs for player-owned cabs, including player-removal cleanup hooks.
- Mirror cab owner metadata onto cab attributes and keep controller ownership synchronized.
- Prefer explicit cab owner metadata for fare ownership before falling back to the current seat occupant.
- Preserve the current Play Solo bootstrap by spawning an owned cab when an initial player exists and keeping the unowned prototype fallback.

## Validation

- `rokit install`
- `rojo build default.project.json --output cab87.rbxlx`
- `git diff --check`

## Not Run

- Roblox Studio Play smoke test for entering, driving, fare completion, and rejoin behavior.