### PR TITLE
[codex] add imported GLB road mesh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,23 +97,26 @@ When you click **Generate Map**, check Studio Output for seed + generator versio
    - `cd tools/intersection-visualizer`
    - `npm ci`
    - `npm run dev`
-2. Open `http://localhost:3000`, author the road graph, and export JSON.
-   - Keep Road-Maker and Roblox mesher changes in sync. See [Road-Maker sync and mesher parity](docs/ROAD_MAKER_SYNC.md).
+2. Open `http://localhost:3000`, author the road graph, then export both:
+   - **Export JSON** for lightweight graph/gameplay data.
+   - **Roblox** for `cab87-road-mesh.glb` plus `cab87-road-mesh.manifest.json`.
 3. In Studio, open **Road Graph Builder**.
 4. Set **Import Y** for the Roblox plane height.
 5. Set **Map ID** to a stable level id such as `downtown_v1`.
 6. Click **Import Graph JSON**.
    - The plugin imports to `Cab87RoadEditor/RoadGraph`.
-   - It builds a disposable preview mesh for quick inspection.
-7. Click **Bake Runtime Geometry**.
-   - If Studio allows programmatic mesh uploads, the plugin uploads or updates permanent mesh assets and stores their IDs in `Cab87RoadEditor/RoadGraphAssets`.
-   - If Studio reports that `CreateAssetAsync` is not available, the plugin builds persistent saved `WedgePart` geometry under `RoadGraphBakedRuntime` instead. This creates no package or mesh asset IDs, but it survives save/reopen and Play.
-   - The bake also creates a hidden `MinimapRoadMesh` for the GPS viewport so Play mode does not generate minimap geometry at runtime.
-   - If an older bake does not include a current `MinimapRoadMesh`, the GPS viewport uses the existing pregenerated `RoadGraphBakedSurfaces` as its fallback.
-   - The bake clears disposable preview mesh folders so Play mode does not render overlapping preview/runtime geometry.
-8. Press Play and test traversal.
+   - It does not run the Luau mesher automatically.
+7. Import `cab87-road-mesh.glb` with Studio's 3D Importer.
+8. Select the imported model or imported MeshParts.
+9. Click **Adopt Imported GLB Mesh** and choose `cab87-road-mesh.manifest.json`.
+   - The plugin moves the imported chunks into `Cab87RoadEditor/RoadGraphBakedRuntime`.
+   - It configures visual, collision, and minimap MeshParts from the manifest.
+   - Play mode uses these imported MeshParts instead of runtime `EditableMesh` generation.
+10. Press Play and test traversal.
 
-For an update to the same map, keep the same **Map ID** and click **Bake Runtime Geometry** again. Asset-backed bakes update existing mesh asset versions when Roblox exposes that API; fallback bakes replace the saved `RoadGraphBakedRuntime` model in the place. For a new level, click **Fork As New Map** or set a new **Map ID** before baking so the new map gets separate baked output.
+**Bake Runtime Geometry** remains available as the older Studio-generated mesh path. Prefer the GLB + manifest workflow for large maps so the TypeScript visualizer remains the source of truth for meshing.
+
+For an update to the same map, keep the same **Map ID**, re-export JSON + Roblox GLB/manifest, import the new GLB, and run **Adopt Imported GLB Mesh** again. For a new level, click **Fork As New Map** or set a new **Map ID** before adopting so the new map gets separate baked output.
 
 ### Dialogue timing workflow
 

--- a/src/client/AuthoredRoadVisuals.client.lua
+++ b/src/client/AuthoredRoadVisuals.client.lua
@@ -4,8 +4,6 @@ local Workspace = game:GetService("Workspace")
 local Shared = ReplicatedStorage:WaitForChild("Shared")
 local Config = require(Shared:WaitForChild("Config"))
 local RoadGraphData = require(Shared:WaitForChild("RoadGraphData"))
-local RoadGraphMesher = require(Shared:WaitForChild("RoadGraphMesher"))
-local RoadMeshBuilder = require(Shared:WaitForChild("RoadMeshBuilder"))
 
 local WORLD_NAME = "Cab87World"
 local CLIENT_VISUALS_NAME = "AuthoredRoadClientVisuals"
@@ -16,6 +14,22 @@ local MAX_DEBUG_PARTS = 12
 local buildToken = 0
 local watchedWorld = nil
 local worldConnections = {}
+local RoadGraphMesher = nil
+local RoadMeshBuilder = nil
+
+local function getRoadGraphMesher()
+	if not RoadGraphMesher then
+		RoadGraphMesher = require(Shared:WaitForChild("RoadGraphMesher"))
+	end
+	return RoadGraphMesher
+end
+
+local function getRoadMeshBuilder()
+	if not RoadMeshBuilder then
+		RoadMeshBuilder = require(Shared:WaitForChild("RoadMeshBuilder"))
+	end
+	return RoadMeshBuilder
+end
 
 local function disconnectWorldConnections()
 	for _, connection in ipairs(worldConnections) do
@@ -175,6 +189,11 @@ local function buildClientVisuals(world)
 	if not (world and world:IsA("Model")) then
 		return
 	end
+	if world:GetAttribute("NeedsClientRoadMesh") == false then
+		clearClientVisuals(world)
+		debugLog("client runtime road mesh skipped: world uses baked MeshParts")
+		return
+	end
 
 	task.spawn(function()
 		local graphRoot = world:FindFirstChild(RUNTIME_GRAPH_DATA_NAME) or world:WaitForChild(RUNTIME_GRAPH_DATA_NAME, 30)
@@ -200,7 +219,7 @@ local function buildClientVisuals(world)
 		clearClientVisuals(world)
 
 		local okMesh, meshDataOrErr = pcall(function()
-			return RoadGraphMesher.buildNetworkMesh(graph, graph.settings)
+			return getRoadGraphMesher().buildNetworkMesh(graph, graph.settings)
 		end)
 		if token ~= buildToken then
 			return
@@ -229,7 +248,7 @@ local function buildClientVisuals(world)
 		)
 
 		local okBuild, resultOrErr = pcall(function()
-			return RoadMeshBuilder.createClassifiedCompactSurfaceMeshes(world, meshDataOrErr, {
+			return getRoadMeshBuilder().createClassifiedCompactSurfaceMeshes(world, meshDataOrErr, {
 				meshFolderName = CLIENT_VISUALS_NAME,
 				generatedBy = CLIENT_MESH_GENERATOR,
 				canCollide = false,

--- a/src/server/AuthoredRoadRuntime.lua
+++ b/src/server/AuthoredRoadRuntime.lua
@@ -4,8 +4,6 @@ local Workspace = game:GetService("Workspace")
 local Shared = ReplicatedStorage:WaitForChild("Shared")
 local Config = require(Shared:WaitForChild("Config"))
 local RoadGraphData = require(Shared:WaitForChild("RoadGraphData"))
-local RoadGraphMesher = require(Shared:WaitForChild("RoadGraphMesher"))
-local RoadMeshBuilder = require(Shared:WaitForChild("RoadMeshBuilder"))
 local RoadSampling = require(Shared:WaitForChild("RoadSampling"))
 local RoadSplineData = require(Shared:WaitForChild("RoadSplineData"))
 
@@ -18,6 +16,7 @@ local RUNTIME_WORLD_NAME = "Cab87World"
 local BAKED_RUNTIME_NAME = "RoadGraphBakedRuntime"
 local BAKED_SURFACES_NAME = "RoadGraphBakedSurfaces"
 local BAKED_COLLISION_NAME = "RoadGraphBakedCollision"
+local ASSETS_NAME = "RoadGraphAssets"
 local LEGACY_COLLISION_NAME = "RoadNetworkCollision"
 local LEGACY_RUNTIME_COLLISION_GENERATOR = "Cab87LegacyRoadRuntimeCollision"
 local ROAD_GRAPH_RUNTIME_MESH_GENERATOR = "Cab87RoadGraphRuntimeMesh"
@@ -30,6 +29,23 @@ local MARKER_TYPE_ATTR = "Cab87MarkerType"
 local ROAD_SOURCE_AUTO = "Auto"
 local ROAD_SOURCE_ROAD_GRAPH = "RoadGraph"
 local ROAD_SOURCE_LEGACY_CURVE = "LegacyCurve"
+
+local RoadGraphMesher = nil
+local RoadMeshBuilder = nil
+
+local function getRoadGraphMesher()
+	if not RoadGraphMesher then
+		RoadGraphMesher = require(Shared:WaitForChild("RoadGraphMesher"))
+	end
+	return RoadGraphMesher
+end
+
+local function getRoadMeshBuilder()
+	if not RoadMeshBuilder then
+		RoadMeshBuilder = require(Shared:WaitForChild("RoadMeshBuilder"))
+	end
+	return RoadMeshBuilder
+end
 
 local function roadDebugLog(message, ...)
 	if Config.authoredRoadDebugLogging == true then
@@ -442,7 +458,7 @@ local function projectCabSpawnToDriveSurface(position, driveSurfaces)
 end
 
 local function createRuntimeGraphMeshes(world, meshData)
-	local result = RoadMeshBuilder.createClassifiedChunkedCollisionMeshes(world, meshData, {
+	local result = getRoadMeshBuilder().createClassifiedChunkedCollisionMeshes(world, meshData, {
 		collisionFolderName = BAKED_COLLISION_NAME,
 		generatedBy = ROAD_GRAPH_RUNTIME_MESH_GENERATOR,
 		chunkSize = ROAD_GRAPH_RUNTIME_CHUNK_STUDS,
@@ -472,6 +488,107 @@ local function createRuntimeGraphMeshes(world, meshData)
 		driveSurfaces = result.driveSurfaces,
 		errors = result.errors,
 		source = "runtime-editable-collision",
+	}
+end
+
+local function configureBakedSurfaceClone(part)
+	part.Anchored = true
+	part.CanCollide = false
+	part.CanTouch = false
+	part.CanQuery = false
+	part.CastShadow = part.CastShadow == true
+	part:SetAttribute("RuntimeClone", true)
+end
+
+local function configureBakedCollisionClone(part)
+	part.Anchored = true
+	part.CanCollide = true
+	part.CanTouch = false
+	part.CanQuery = true
+	part.Transparency = 1
+	part.CastShadow = false
+	part:SetAttribute("DriveSurface", true)
+	part:SetAttribute("RuntimeClone", true)
+end
+
+local function cloneBakedPartFolder(sourceFolder, world, folderName, configurePart)
+	if not sourceFolder then
+		return nil, {}
+	end
+
+	local existing = world:FindFirstChild(folderName)
+	if existing then
+		existing:Destroy()
+	end
+
+	local folder = Instance.new("Folder")
+	folder.Name = folderName
+	for name, value in pairs(sourceFolder:GetAttributes()) do
+		folder:SetAttribute(name, value)
+	end
+	folder.Parent = world
+
+	local parts = {}
+	for _, child in ipairs(sourceFolder:GetChildren()) do
+		local clone = child:Clone()
+		clone.Parent = folder
+	end
+	collectBaseParts(folder, parts)
+	for _, part in ipairs(parts) do
+		configurePart(part)
+	end
+	folder:SetAttribute("RuntimeClone", true)
+	folder:SetAttribute("PartCount", #parts)
+	return folder, parts
+end
+
+local function canUseImportedBakedRuntime(root)
+	local assets = root and root:FindFirstChild(ASSETS_NAME)
+	local bakedContainer = root and root:FindFirstChild(BAKED_RUNTIME_NAME)
+	if not (assets and bakedContainer) then
+		return false
+	end
+	if assets:GetAttribute("BakeMode") ~= "importedGlbManifest" then
+		return false
+	end
+	if assets:GetAttribute("Stale") == true then
+		return false
+	end
+	return bakedContainer:GetAttribute("BakeMode") == "importedGlbManifest"
+end
+
+local function useImportedBakedGraphMeshes(root, world)
+	if not canUseImportedBakedRuntime(root) then
+		return nil
+	end
+
+	local bakedContainer = root:FindFirstChild(BAKED_RUNTIME_NAME)
+	local sourceSurfaces = bakedContainer and bakedContainer:FindFirstChild(BAKED_SURFACES_NAME)
+	local sourceCollision = bakedContainer and bakedContainer:FindFirstChild(BAKED_COLLISION_NAME)
+	if not (sourceSurfaces and sourceCollision) then
+		return nil, { "imported GLB bake is missing surface or collision folders" }
+	end
+
+	local meshFolder, visibleParts = cloneBakedPartFolder(sourceSurfaces, world, BAKED_SURFACES_NAME, configureBakedSurfaceClone)
+	local collisionFolder, collisionParts = cloneBakedPartFolder(sourceCollision, world, BAKED_COLLISION_NAME, configureBakedCollisionClone)
+	if #collisionParts == 0 then
+		if meshFolder then
+			meshFolder:Destroy()
+		end
+		if collisionFolder then
+			collisionFolder:Destroy()
+		end
+		return nil, { "imported GLB bake had no collision MeshParts" }
+	end
+
+	return {
+		meshFolder = meshFolder,
+		collisionFolder = collisionFolder,
+		visibleParts = visibleParts,
+		collisionParts = collisionParts,
+		driveSurfaces = collisionParts,
+		errors = {},
+		source = "imported-glb-manifest",
 	}
 end
 
@@ -507,7 +624,7 @@ local function buildAuthoredCabCompany(root, world, driveSurfaces, crashObstacle
 end
 
 local function buildGraphMeshes(root, world, graph)
-	local meshData = RoadGraphMesher.buildNetworkMesh(graph, graph.settings)
+	local meshData = getRoadGraphMesher().buildNetworkMesh(graph, graph.settings)
 	local runtimeMeshResult = createRuntimeGraphMeshes(world, meshData)
 	roadDebugLog(
 		"generated runtime graph collision meshes: collisionParts=%d",
@@ -858,7 +975,19 @@ local function createGraphWorld(root, graph)
 
 	RoadGraphData.writeGraph(world, graph, RoadGraphData.RUNTIME_DATA_NAME)
 
-	local meshData, meshBuild = buildGraphMeshes(root, world, graph)
+	local meshData = nil
+	local meshBuild, importedMeshErrors = useImportedBakedGraphMeshes(root, world)
+	local importedMeshBuild = nil
+	if meshBuild then
+		importedMeshBuild = meshBuild
+		world:SetAttribute("NeedsClientRoadMesh", false)
+		roadDebugLog("using imported GLB road graph meshes: visibleParts=%d collisionParts=%d", #meshBuild.visibleParts, #meshBuild.collisionParts)
+	else
+		if importedMeshErrors and #importedMeshErrors > 0 then
+			roadDebugWarn("imported GLB mesh skipped: %s", table.concat(importedMeshErrors, " | "))
+		end
+		meshData, meshBuild = buildGraphMeshes(root, world, graph)
+	end
 	local minimapMesh, minimapMeshErrors = useBakedMinimapRoadMesh(root, world)
 	local driveSurfaces = {}
 	local crashObstacles = {}
@@ -878,24 +1007,38 @@ local function createGraphWorld(root, graph)
 		spawnPose = cabCompanySpawnPose
 	end
 
-	local roadEdgeTriangleCount = #(meshData.roadEdgeTriangles or {})
-	local roadHubTriangleCount = #(meshData.roadHubTriangles or {})
-	local polygonFillTriangleCount = 0
-	for _, fill in ipairs(meshData.polygonTriangles or meshData.polygonFills or {}) do
-		polygonFillTriangleCount += #(fill.triangles or {})
+	local assets = root:FindFirstChild(ASSETS_NAME)
+	local function meshCountOrAsset(triangles, attributeName)
+		if meshData then
+			return #(triangles or {})
+		end
+		return tonumber(assets and assets:GetAttribute(attributeName)) or 0
+	end
+
+	local roadTriangleCount = meshCountOrAsset(meshData and meshData.roadTriangles, "RoadTriangles")
+	local roadEdgeTriangleCount = meshCountOrAsset(meshData and meshData.roadEdgeTriangles, "RoadEdgeTriangles")
+	local roadHubTriangleCount = meshCountOrAsset(meshData and meshData.roadHubTriangles, "RoadHubTriangles")
+	local sidewalkTriangleCount = meshCountOrAsset(meshData and meshData.sidewalkTriangles, "SidewalkTriangles")
+	local crosswalkTriangleCount = meshCountOrAsset(meshData and meshData.crosswalkTriangles, "CrosswalkTriangles")
+	local polygonFillTriangleCount = tonumber(assets and assets:GetAttribute("PolygonFillTriangles")) or 0
+	if meshData then
+		polygonFillTriangleCount = 0
+		for _, fill in ipairs(meshData.polygonTriangles or meshData.polygonFills or {}) do
+			polygonFillTriangleCount += #(fill.triangles or {})
+		end
 	end
 
 	world:SetAttribute("AuthoredRoadFormat", "RoadGraph")
 	world:SetAttribute("AuthoredRoadNodeCount", #(graph.nodes or {}))
 	world:SetAttribute("AuthoredRoadEdgeCount", #(graph.edges or {}))
-	world:SetAttribute("AuthoredRoadRoadTriangles", #(meshData.roadTriangles or {}))
+	world:SetAttribute("AuthoredRoadRoadTriangles", roadTriangleCount)
 	world:SetAttribute("AuthoredRoadRoadEdgeTriangles", roadEdgeTriangleCount)
 	world:SetAttribute("AuthoredRoadRoadHubTriangles", roadHubTriangleCount)
-	world:SetAttribute("AuthoredRoadSidewalkTriangles", #(meshData.sidewalkTriangles or {}))
-	world:SetAttribute("AuthoredRoadCrosswalkTriangles", #(meshData.crosswalkTriangles or {}))
+	world:SetAttribute("AuthoredRoadSidewalkTriangles", sidewalkTriangleCount)
+	world:SetAttribute("AuthoredRoadCrosswalkTriangles", crosswalkTriangleCount)
 	world:SetAttribute("AuthoredRoadPolygonFillTriangles", polygonFillTriangleCount)
 	world:SetAttribute("AuthoredRoadMeshSource", meshBuild.source or "runtime")
-	world:SetAttribute("AuthoredRoadVisualSource", "client-runtime-editable-mesh")
+	world:SetAttribute("AuthoredRoadVisualSource", if importedMeshBuild then "imported-glb-manifest" else "client-runtime-editable-mesh")
 	world:SetAttribute("AuthoredRoadServerCollisionSource", BAKED_COLLISION_NAME)
 	world:SetAttribute("AuthoredRoadServerMeshError", "")
 	world:SetAttribute("MinimapRoadMeshSource", minimapMesh and MINIMAP_ROAD_MESH_NAME or BAKED_SURFACES_NAME)
@@ -906,11 +1049,11 @@ local function createGraphWorld(root, graph)
 		"road graph world built: nodes=%d edges=%d roadTris=%d roadEdgeTris=%d roadHubTris=%d sidewalkTris=%d crosswalkTris=%d polygonFillTris=%d driveSurfaces=%d spawn=(%.1f, %.1f, %.1f) forward=(%.2f, %.2f, %.2f)",
 		#(graph.nodes or {}),
 		#(graph.edges or {}),
-		#(meshData.roadTriangles or {}),
+		roadTriangleCount,
 		roadEdgeTriangleCount,
 		roadHubTriangleCount,
-		#(meshData.sidewalkTriangles or {}),
-		#(meshData.crosswalkTriangles or {}),
+		sidewalkTriangleCount,
+		crosswalkTriangleCount,
 		polygonFillTriangleCount,
 		#driveSurfaces,
 		spawnPose.position.X,

--- a/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
+++ b/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
@@ -942,6 +942,26 @@ local function applyManifestPartOptions(part, chunk, mapIdValue)
 	end
 end
 
+local function applyImportedMeshTransform(part)
+	if part:GetAttribute("ImportTransformApplied") == true then
+		return
+	end
+
+	local pointScale = importPointScale
+	local planeY = importPlaneY
+	local position = part.Position
+	local rotation = part.CFrame - position
+	part.Size *= pointScale
+	part.CFrame = CFrame.new(
+		position.X * pointScale,
+		planeY + position.Y * pointScale,
+		position.Z * pointScale
+	) * rotation
+	part:SetAttribute("ImportTransformApplied", true)
+	part:SetAttribute("ImportPlaneY", planeY)
+	part:SetAttribute("ImportPointScale", pointScale)
+end
+
 local function cloneMinimapPart(sourcePart, parent, mapIdValue)
 	local clone = sourcePart:Clone()
 	clone.Name = sourcePart.Name
@@ -968,6 +988,9 @@ local function adoptImportedMeshFromManifest()
 		return nil
 	end
 	if not refreshMapId() then
+		return nil
+	end
+	if not refreshImportPlane() then
 		return nil
 	end
 	refreshImportScales()
@@ -1053,6 +1076,7 @@ local function adoptImportedMeshFromManifest()
 		local chunk = match.chunk
 		local part = match.part
 		local isCollision = tostring(chunk.kind or "surface") == "collision"
+		applyImportedMeshTransform(part)
 		applyManifestPartOptions(part, chunk, mapId)
 		part.Parent = if isCollision then collisionFolder else surfacesFolder
 

--- a/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
+++ b/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
@@ -3,6 +3,7 @@
 --   %LOCALAPPDATA%\Roblox\Plugins\Cab87RoadGraphBuilder.plugin.lua
 
 local ChangeHistoryService = game:GetService("ChangeHistoryService")
+local HttpService = game:GetService("HttpService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 local Selection = game:GetService("Selection")
@@ -32,6 +33,8 @@ local MINIMAP_MESH_VERSION = 3
 local MINIMAP_MESH_CHUNK_STUDS = 1024
 local MINIMAP_MESH_MAX_PARTS = 256
 local IMPORT_FILE_FILTER = { "json" }
+local MESH_MANIFEST_SCHEMA = "cab87-road-mesh-manifest"
+local MESH_MANIFEST_VERSION = 1
 local IMPORT_PLANE_Y_SETTING = "cab87_road_graph_import_plane_y"
 local IMPORT_POINT_SCALE_SETTING = "cab87_road_graph_import_point_scale"
 local IMPORT_WIDTH_SCALE_SETTING = "cab87_road_graph_import_width_scale"
@@ -364,6 +367,7 @@ local importWidthScaleSlider = makeSliderRow("Width Scale", importWidthScale)
 local mapIdInput = makeInputRow("Map ID", mapId)
 local importButton = makeButton("Import Graph JSON")
 local bakeAssetsButton = makeButton("Bake Runtime Geometry")
+local adoptImportedMeshButton = makeButton("Adopt Imported GLB Mesh")
 local forkMapButton = makeButton("Fork As New Map")
 local clearAllButton = makeButton("Clear All Road Data")
 local setCabSpawnButton = makeButton("Set Cab Spawn From Camera")
@@ -393,6 +397,33 @@ local function stripUtf8Bom(text)
 	return text
 end
 
+local function requireFreshModule(moduleScript)
+	local clone = moduleScript:Clone()
+	clone.Name = moduleScript.Name .. "_PluginFreshRequire"
+	clone.Parent = moduleScript.Parent
+	local ok, result = pcall(require, clone)
+	clone:Destroy()
+	return ok, result
+end
+
+local function getGraphDataModule()
+	local shared = ReplicatedStorage:FindFirstChild("Shared")
+	if not shared then
+		return nil, "ReplicatedStorage.Shared was not found. Start Rojo sync before using this plugin."
+	end
+
+	local graphDataModule = shared:FindFirstChild("RoadGraphData")
+	if not graphDataModule then
+		return nil, "Shared RoadGraphData module is missing. Start Rojo sync or rebuild the place from source."
+	end
+
+	local okGraphData, graphDataOrErr = requireFreshModule(graphDataModule)
+	if not okGraphData then
+		return nil, "RoadGraphData failed to load: " .. tostring(graphDataOrErr)
+	end
+	return graphDataOrErr, nil
+end
+
 local function getSharedModules()
 	local shared = ReplicatedStorage:FindFirstChild("Shared")
 	if not shared then
@@ -406,24 +437,15 @@ local function getSharedModules()
 		return nil, nil, nil, "Shared road graph modules are missing. Start Rojo sync or rebuild the place from source."
 	end
 
-	local function requireFresh(moduleScript)
-		local clone = moduleScript:Clone()
-		clone.Name = moduleScript.Name .. "_PluginFreshRequire"
-		clone.Parent = moduleScript.Parent
-		local ok, result = pcall(require, clone)
-		clone:Destroy()
-		return ok, result
-	end
-
-	local okGraphData, graphDataOrErr = requireFresh(graphDataModule)
+	local okGraphData, graphDataOrErr = requireFreshModule(graphDataModule)
 	if not okGraphData then
 		return nil, nil, nil, "RoadGraphData failed to load: " .. tostring(graphDataOrErr)
 	end
-	local okMesher, mesherOrErr = requireFresh(mesherModule)
+	local okMesher, mesherOrErr = requireFreshModule(mesherModule)
 	if not okMesher then
 		return nil, nil, nil, "RoadGraphMesher failed to load: " .. tostring(mesherOrErr)
 	end
-	local okMeshBuilder, meshBuilderOrErr = requireFresh(meshBuilderModule)
+	local okMeshBuilder, meshBuilderOrErr = requireFreshModule(meshBuilderModule)
 	if not okMeshBuilder then
 		return nil, nil, nil, "RoadMeshBuilder failed to load: " .. tostring(meshBuilderOrErr)
 	end
@@ -695,7 +717,424 @@ local function countPolygonFillTriangles(meshData)
 	return count
 end
 
-local function isPlayRunning()
+local function colorFromHex(value, fallback)
+	if type(value) ~= "string" then
+		return fallback
+	end
+
+	local hex = string.gsub(value, "#", "")
+	if #hex ~= 6 then
+		return fallback
+	end
+
+	local r = tonumber(string.sub(hex, 1, 2), 16)
+	local g = tonumber(string.sub(hex, 3, 4), 16)
+	local b = tonumber(string.sub(hex, 5, 6), 16)
+	if not (r and g and b) then
+		return fallback
+	end
+
+	return Color3.fromRGB(r, g, b)
+end
+
+local function enumByName(enumType, value, fallback)
+	if type(value) ~= "string" or value == "" then
+		return fallback
+	end
+
+	local ok, item = pcall(function()
+		return enumType[value]
+	end)
+	if ok and item then
+		return item
+	end
+	return fallback
+end
+
+local function normalizeMeshName(value)
+	local text = string.lower(tostring(value or ""))
+	return string.gsub(text, "[^%w]", "")
+end
+
+local function collectMeshParts(instance, target)
+	if not instance then
+		return
+	end
+	if instance:IsA("MeshPart") then
+		table.insert(target, instance)
+	end
+	for _, descendant in ipairs(instance:GetDescendants()) do
+		if descendant:IsA("MeshPart") then
+			table.insert(target, descendant)
+		end
+	end
+end
+
+local function selectedImportedMeshParts()
+	local selected = Selection:Get()
+	local parts = {}
+	local seen = {}
+
+	for _, instance in ipairs(selected) do
+		local collected = {}
+		collectMeshParts(instance, collected)
+		for _, part in ipairs(collected) do
+			if not seen[part] then
+				seen[part] = true
+				table.insert(parts, part)
+			end
+		end
+	end
+
+	return parts
+end
+
+local function indexMeshPartsByName(parts)
+	local exact = {}
+	local normalized = {}
+
+	for _, part in ipairs(parts or {}) do
+		exact[part.Name] = exact[part.Name] or {}
+		table.insert(exact[part.Name], part)
+
+		local normalizedName = normalizeMeshName(part.Name)
+		normalized[normalizedName] = normalized[normalizedName] or {}
+		table.insert(normalized[normalizedName], part)
+	end
+
+	return exact, normalized
+end
+
+local function takeFirstUnused(candidates, usedParts)
+	for _, part in ipairs(candidates or {}) do
+		if not usedParts[part] then
+			usedParts[part] = true
+			return part
+		end
+	end
+	return nil
+end
+
+local function findManifestPart(chunk, exactParts, normalizedParts, allParts, usedParts)
+	local targetName = tostring(chunk.name or "")
+	local part = takeFirstUnused(exactParts[targetName], usedParts)
+	if part then
+		return part
+	end
+
+	local normalizedTarget = normalizeMeshName(targetName)
+	part = takeFirstUnused(normalizedParts[normalizedTarget], usedParts)
+	if part then
+		return part
+	end
+
+	for _, candidate in ipairs(allParts or {}) do
+		if not usedParts[candidate] then
+			local candidateName = normalizeMeshName(candidate.Name)
+			if string.sub(candidateName, 1, #normalizedTarget) == normalizedTarget then
+				usedParts[candidate] = true
+				return candidate
+			end
+		end
+	end
+
+	return nil
+end
+
+local function decodeMeshManifest(contents)
+	local ok, manifestOrErr = pcall(function()
+		return HttpService:JSONDecode(contents)
+	end)
+	if not ok or type(manifestOrErr) ~= "table" then
+		return nil, "manifest JSON decode failed: " .. tostring(manifestOrErr)
+	end
+
+	local manifest = manifestOrErr
+	if manifest.schema ~= MESH_MANIFEST_SCHEMA then
+		return nil, "unsupported manifest schema: " .. tostring(manifest.schema)
+	end
+	if tonumber(manifest.version) ~= MESH_MANIFEST_VERSION then
+		return nil, "unsupported manifest version: " .. tostring(manifest.version)
+	end
+	if type(manifest.chunks) ~= "table" or #manifest.chunks == 0 then
+		return nil, "manifest had no chunks"
+	end
+	return manifest, nil
+end
+
+local function manifestSetting(manifest, key)
+	local settings = manifest and manifest.settings
+	if type(settings) ~= "table" then
+		return nil
+	end
+	return settings[key]
+end
+
+local function firstListValues(values, maxCount)
+	local result = {}
+	for index = 1, math.min(#values, maxCount) do
+		table.insert(result, tostring(values[index]))
+	end
+	return result
+end
+
+local function promptMeshManifest()
+	local okFile, fileOrErr = pcall(function()
+		return StudioService:PromptImportFileAsync(IMPORT_FILE_FILTER)
+	end)
+	if not okFile then
+		return nil, "manifest import failed to open file picker: " .. tostring(fileOrErr)
+	end
+	if not fileOrErr then
+		return nil, "manifest import canceled"
+	end
+
+	local contents, readErr = readImportedFileContents(fileOrErr)
+	if not contents then
+		return nil, tostring(readErr)
+	end
+	return decodeMeshManifest(contents)
+end
+
+local function applyManifestPartOptions(part, chunk, mapIdValue)
+	local kind = tostring(chunk.kind or "surface")
+	local isCollision = kind == "collision"
+
+	part.Name = tostring(chunk.name or part.Name)
+	part.Anchored = true
+	part.CanCollide = chunk.canCollide == true
+	part.CanQuery = chunk.canQuery == true
+	part.CanTouch = chunk.canTouch == true
+	part.CastShadow = chunk.castShadow == true
+	part.Transparency = tonumber(chunk.transparency) or (if isCollision then 1 else 0)
+	part.Color = colorFromHex(chunk.color, if isCollision then Color3.fromRGB(56, 189, 248) else Color3.fromRGB(28, 28, 32))
+	part.Material = enumByName(Enum.Material, chunk.material, Enum.Material.Asphalt)
+	pcall(function()
+		part.DoubleSided = true
+	end)
+	pcall(function()
+		part.CollisionFidelity = enumByName(
+			Enum.CollisionFidelity,
+			chunk.collisionFidelity,
+			if isCollision then Enum.CollisionFidelity.PreciseConvexDecomposition else Enum.CollisionFidelity.Box
+		)
+	end)
+
+	part:SetAttribute("MapId", mapIdValue)
+	part:SetAttribute("BakedRoadGraphMesh", true)
+	part:SetAttribute("BakeMode", "importedGlbManifest")
+	part:SetAttribute("MeshMode", "importedGlbManifest")
+	part:SetAttribute("MeshContentMode", "importedAsset")
+	part:SetAttribute("GeneratedBy", BAKED_MESH_GENERATOR_NAME)
+	part:SetAttribute("ManifestChunkName", tostring(chunk.name or part.Name))
+	part:SetAttribute("ManifestLayer", tostring(chunk.layer or ""))
+	part:SetAttribute("SurfaceType", tostring(chunk.surfaceType or ""))
+	part:SetAttribute("TriangleCount", tonumber(chunk.triangleCount) or nil)
+	part:SetAttribute("InputTriangleCount", tonumber(chunk.inputTriangleCount) or nil)
+	part:SetAttribute("MeshChunkKey", tostring(chunk.chunkKey or ""))
+	part:SetAttribute("MeshBatchIndex", tonumber(chunk.batchIndex) or nil)
+
+	if isCollision or chunk.driveSurface == true then
+		part:SetAttribute("DriveSurface", true)
+	end
+	if tostring(chunk.surfaceType or "") == "polygonFill" then
+		part:SetAttribute("BakedPolygonFillMesh", true)
+	end
+end
+
+local function cloneMinimapPart(sourcePart, parent, mapIdValue)
+	local clone = sourcePart:Clone()
+	clone.Name = sourcePart.Name
+	clone.Anchored = true
+	clone.CanCollide = false
+	clone.CanTouch = false
+	clone.CanQuery = false
+	clone.CastShadow = false
+	clone.Transparency = 1
+	clone:SetAttribute("MapId", mapIdValue)
+	clone:SetAttribute("BakedRoadGraphMesh", true)
+	clone:SetAttribute("BakedMinimapRoadMesh", true)
+	clone:SetAttribute("MinimapRoadMesh", true)
+	clone:SetAttribute("GeneratedBy", MINIMAP_MESH_GENERATOR_NAME)
+	clone.Parent = parent
+	return clone
+end
+
+local isPlayRunning
+
+local function adoptImportedMeshFromManifest()
+	if isPlayRunning() then
+		setStatus("Adopt skipped: stop Play before adopting imported road meshes.")
+		return nil
+	end
+	if not refreshMapId() then
+		return nil
+	end
+	refreshImportScales()
+
+	local selectedParts = selectedImportedMeshParts()
+	if #selectedParts == 0 then
+		setStatus("Select the imported GLB model or its MeshParts before adopting.")
+		return nil
+	end
+
+	setStatus("Choose the Roblox mesh manifest exported with the GLB...")
+	local manifest, manifestErr = promptMeshManifest()
+	if not manifest then
+		setStatus("Adopt failed: " .. tostring(manifestErr))
+		return nil
+	end
+
+	local exactParts, normalizedParts = indexMeshPartsByName(selectedParts)
+	local usedParts = {}
+	local matches = {}
+	local missing = {}
+
+	for _, chunk in ipairs(manifest.chunks or {}) do
+		local part = findManifestPart(chunk, exactParts, normalizedParts, selectedParts, usedParts)
+		if part then
+			table.insert(matches, { chunk = chunk, part = part })
+		else
+			table.insert(missing, tostring(chunk.name or "?"))
+		end
+	end
+
+	if #missing > 0 then
+		setStatus(string.format(
+			"Adopt failed: selected import is missing %d manifest chunks. First missing: %s",
+			#missing,
+			table.concat(firstListValues(missing, 5), ", ")
+		))
+		return nil
+	end
+
+	ChangeHistoryService:SetWaypoint("cab87 road graph before imported mesh adopt")
+	local root = getOrCreateRoot()
+	clearChild(root, BAKED_RUNTIME_BUILDING_NAME)
+
+	local bakedRoot = Instance.new("Model")
+	bakedRoot.Name = BAKED_RUNTIME_BUILDING_NAME
+	bakedRoot:SetAttribute("MapId", mapId)
+	bakedRoot:SetAttribute("BakedRoadGraphRuntime", true)
+	bakedRoot:SetAttribute("BakeMode", "importedGlbManifest")
+	bakedRoot:SetAttribute("MeshManifestSchema", manifest.schema)
+	bakedRoot:SetAttribute("MeshManifestVersion", manifest.version)
+	setBakeScaleAttributes(bakedRoot)
+	bakedRoot.Parent = root
+
+	local surfacesFolder = createFolder(bakedRoot, BAKED_SURFACES_NAME)
+	surfacesFolder:SetAttribute("MapId", mapId)
+	surfacesFolder:SetAttribute("GeneratedBy", BAKED_MESH_GENERATOR_NAME)
+	surfacesFolder:SetAttribute("MeshMode", "importedGlbManifest")
+
+	local collisionFolder = createFolder(bakedRoot, BAKED_COLLISION_NAME)
+	collisionFolder:SetAttribute("MapId", mapId)
+	collisionFolder:SetAttribute("GeneratedBy", BAKED_MESH_GENERATOR_NAME)
+	collisionFolder:SetAttribute("MeshMode", "importedGlbManifest")
+
+	local minimapFolder = createFolder(bakedRoot, MINIMAP_ROAD_MESH_NAME)
+	minimapFolder:SetAttribute("MapId", mapId)
+	minimapFolder:SetAttribute("BakedMinimapRoadMesh", true)
+	minimapFolder:SetAttribute("GeneratedBy", MINIMAP_MESH_GENERATOR_NAME)
+	minimapFolder:SetAttribute("Version", MINIMAP_MESH_VERSION)
+	minimapFolder:SetAttribute("MeshMode", "importedGlbManifest")
+	minimapFolder:SetAttribute("ChunkSize", tonumber(manifestSetting(manifest, "chunkSize")) or nil)
+
+	local surfaceParts = 0
+	local collisionParts = 0
+	local minimapParts = 0
+	local totalTriangles = 0
+	local roadTriangles = 0
+	local sidewalkTriangles = 0
+	local crosswalkTriangles = 0
+	local polygonFillTriangles = 0
+
+	for _, match in ipairs(matches) do
+		local chunk = match.chunk
+		local part = match.part
+		local isCollision = tostring(chunk.kind or "surface") == "collision"
+		applyManifestPartOptions(part, chunk, mapId)
+		part.Parent = if isCollision then collisionFolder else surfacesFolder
+
+		local triangleCount = tonumber(chunk.triangleCount) or 0
+		totalTriangles += triangleCount
+		if isCollision then
+			collisionParts += 1
+		else
+			surfaceParts += 1
+			local surfaceType = tostring(chunk.surfaceType or "")
+			if surfaceType == "road" then
+				roadTriangles += triangleCount
+			elseif surfaceType == "sidewalk" then
+				sidewalkTriangles += triangleCount
+			elseif surfaceType == "crosswalk" then
+				crosswalkTriangles += triangleCount
+			elseif surfaceType == "polygonFill" then
+				polygonFillTriangles += triangleCount
+			end
+			if surfaceType == "road" or surfaceType == "crosswalk" then
+				cloneMinimapPart(part, minimapFolder, mapId)
+				minimapParts += 1
+			end
+		end
+	end
+
+	if collisionParts == 0 then
+		bakedRoot:Destroy()
+		setStatus("Adopt failed: manifest did not provide collision chunks.")
+		return nil
+	end
+
+	hideDefaultBaseplate()
+	clearChild(root, BAKED_RUNTIME_NAME)
+	clearChild(root, BAKED_SURFACES_NAME)
+	clearChild(root, BAKED_COLLISION_NAME)
+	clearChild(root, MINIMAP_ROAD_MESH_NAME)
+	clearChild(root, ASSETS_NAME)
+	clearPreviewMeshes(root)
+	bakedRoot.Name = BAKED_RUNTIME_NAME
+
+	local assets = getOrCreateAssetsFolder(root)
+	setBakeScaleAttributes(assets)
+	assets:SetAttribute("Stale", false)
+	assets:SetAttribute("BakeMode", "importedGlbManifest")
+	assets:SetAttribute("LastBakeUnix", os.time())
+	assets:SetAttribute("BakedPartCount", surfaceParts + collisionParts + minimapParts)
+	assets:SetAttribute("PreviewPartCount", surfaceParts)
+	assets:SetAttribute("CollisionPartCount", collisionParts)
+	assets:SetAttribute("MinimapPartCount", minimapParts)
+	assets:SetAttribute("RoadTriangles", roadTriangles)
+	assets:SetAttribute("SidewalkTriangles", sidewalkTriangles)
+	assets:SetAttribute("CrosswalkTriangles", crosswalkTriangles)
+	assets:SetAttribute("PolygonFillTriangles", polygonFillTriangles)
+	assets:SetAttribute("ManifestChunkCount", #(manifest.chunks or {}))
+	assets:SetAttribute("ManifestTriangleCount", totalTriangles)
+	assets:SetAttribute("ChunkSize", tonumber(manifestSetting(manifest, "chunkSize")) or nil)
+	assets:SetAttribute("MaxSurfaceTriangles", tonumber(manifestSetting(manifest, "maxSurfaceTriangles")) or nil)
+	assets:SetAttribute("MaxCollisionInputTriangles", tonumber(manifestSetting(manifest, "maxCollisionInputTriangles")) or nil)
+
+	surfacesFolder:SetAttribute("SurfacePartCount", surfaceParts)
+	collisionFolder:SetAttribute("CollisionPartCount", collisionParts)
+	minimapFolder:SetAttribute("SurfacePartCount", minimapParts)
+
+	Selection:Set({ bakedRoot })
+	ChangeHistoryService:SetWaypoint("cab87 road graph after imported mesh adopt")
+	setStatus(string.format(
+		"Adopted imported GLB mesh for map %s: %d surface parts, %d collision parts, %d minimap parts.",
+		mapId,
+		surfaceParts,
+		collisionParts,
+		minimapParts
+	))
+
+	return {
+		surfaceParts = surfaceParts,
+		collisionParts = collisionParts,
+		minimapParts = minimapParts,
+	}
+end
+
+function isPlayRunning()
 	local ok, running = pcall(function()
 		return RunService:IsRunning()
 	end)
@@ -896,7 +1335,7 @@ local function importGraphJson()
 	keepGraphAboveDefaultBaseplate()
 	setStatus("Importing road graph JSON...")
 
-	local RoadGraphData, _RoadGraphMesher, _RoadMeshBuilder, moduleErr = getSharedModules()
+	local RoadGraphData, moduleErr = getGraphDataModule()
 	if moduleErr then
 		setStatus(moduleErr)
 		return
@@ -933,24 +1372,10 @@ local function importGraphJson()
 	ChangeHistoryService:SetWaypoint("cab87 road graph before import")
 	local root = getOrCreateRoot()
 	RoadGraphData.writeGraph(root, graph)
-	setStatus(string.format(
-		"Imported graph data: %d nodes, %d edges. Building optimized preview MeshParts...",
-		#graph.nodes,
-		#graph.edges
-	))
 	markBakedAssetsStale(root, "graph imported")
-	local okBake, bakeResultOrErr = pcall(bakeMeshAssets)
 	ChangeHistoryService:SetWaypoint("cab87 road graph after import")
-	if not okBake then
-		setStatus("Imported graph, but runtime bake failed: " .. tostring(bakeResultOrErr))
-		return
-	end
-	if not bakeResultOrErr then
-		return
-	end
-
 	setStatus(string.format(
-		"Imported and baked graph: %d nodes, %d edges at Y=%s, %s.",
+		"Imported graph data: %d nodes, %d edges at Y=%s, %s. Import the exported GLB, select it, then click Adopt Imported GLB Mesh.",
 		#graph.nodes,
 		#graph.edges,
 		tostring(importPlaneY),
@@ -1069,6 +1494,12 @@ bakeAssetsButton.MouseButton1Click:Connect(function()
 		setStatus("Bake failed: " .. tostring(err))
 	end
 end)
+adoptImportedMeshButton.MouseButton1Click:Connect(function()
+	local ok, err = pcall(adoptImportedMeshFromManifest)
+	if not ok then
+		setStatus("Adopt failed: " .. tostring(err))
+	end
+end)
 forkMapButton.MouseButton1Click:Connect(function()
 	ChangeHistoryService:SetWaypoint("cab87 road graph before fork")
 	forkAsNewMap()
@@ -1133,6 +1564,11 @@ local function autoReloadPreviewMeshes()
 		local root = Workspace:FindFirstChild(ROOT_NAME)
 		local graphFolder = root and root:FindFirstChild(ROAD_GRAPH_NAME)
 		if not graphFolder then
+			return
+		end
+		local assets = root:FindFirstChild(ASSETS_NAME)
+		if assets and assets:GetAttribute("BakeMode") == "importedGlbManifest" and assets:GetAttribute("Stale") ~= true then
+			setStatus("Loaded imported GLB road mesh bake. Runtime will use the adopted MeshParts.")
 			return
 		end
 

--- a/tools/intersection-visualizer/README.md
+++ b/tools/intersection-visualizer/README.md
@@ -11,7 +11,7 @@ npm ci
 npm run dev
 ```
 
-Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for distance-based mesh density, then export JSON. The export format is `schema: "cab87-road-network"` / `version: 1` and is imported by the `Cab87 Road Graph Builder` Studio plugin. In Studio, import the JSON, set a stable map ID, then use **Bake Runtime Geometry** so runtime uses baked road, sidewalk, crosswalk, and collision geometry. If Roblox Studio has not enabled programmatic mesh asset upload yet, the plugin falls back to persistent saved `WedgePart` geometry under `RoadGraphBakedRuntime` instead of uploading package or mesh asset IDs.
+Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for distance-based mesh density, then export JSON. The export format is `schema: "cab87-road-network"` / `version: 1` and is imported by the `Cab87 Road Graph Builder` Studio plugin. You can also export the current generated mesh as OBJ or GLB from the header; GLB keeps material colors, while OBJ is mostly geometry/object names. In Studio, import the JSON, set a stable map ID, then use **Bake Runtime Geometry** so runtime uses baked road, sidewalk, crosswalk, and collision geometry. If Roblox Studio has not enabled programmatic mesh asset upload yet, the plugin falls back to persistent saved `WedgePart` geometry under `RoadGraphBakedRuntime` instead of uploading package or mesh asset IDs.
 
 Mesher changes must stay in parity with Roblox's Luau port in `src/shared/RoadGraphMesher.lua`.
 See [`../../docs/ROAD_MAKER_SYNC.md`](../../docs/ROAD_MAKER_SYNC.md) before changing

--- a/tools/intersection-visualizer/README.md
+++ b/tools/intersection-visualizer/README.md
@@ -11,7 +11,7 @@ npm ci
 npm run dev
 ```
 
-Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for distance-based mesh density, then export JSON. The export format is `schema: "cab87-road-network"` / `version: 1` and is imported by the `Cab87 Road Graph Builder` Studio plugin. You can also export the current generated mesh as OBJ or GLB from the header; GLB keeps material colors, while OBJ is mostly geometry/object names. In Studio, import the JSON, set a stable map ID, then use **Bake Runtime Geometry** so runtime uses baked road, sidewalk, crosswalk, and collision geometry. If Roblox Studio has not enabled programmatic mesh asset upload yet, the plugin falls back to persistent saved `WedgePart` geometry under `RoadGraphBakedRuntime` instead of uploading package or mesh asset IDs.
+Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for distance-based mesh density, then export JSON. The export format is `schema: "cab87-road-network"` / `version: 1` and is imported by the `Cab87 Road Graph Builder` Studio plugin. You can also export the current generated mesh as OBJ or GLB from the header; GLB keeps material colors, while OBJ is mostly geometry/object names. Use **Roblox** export for the large-map workflow: it downloads a chunked GLB plus `cab87-road-mesh.manifest.json`, with visual and collision objects split by tile and triangle budget. In Studio, import the JSON, import the GLB with the 3D Importer, select the imported model, then click **Adopt Imported GLB Mesh** in the plugin and choose the manifest.
 
 Mesher changes must stay in parity with Roblox's Luau port in `src/shared/RoadGraphMesher.lua`.
 See [`../../docs/ROAD_MAKER_SYNC.md`](../../docs/ROAD_MAKER_SYNC.md) before changing

--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -8,7 +8,7 @@ import Sidebar from './components/Sidebar';
 import Header from './components/Header';
 import { drawNetwork2D } from './lib/render2d';
 import { buildNetworkMesh } from './lib/meshing';
-import { exportRoadMeshGlb, exportRoadMeshObj } from './lib/meshExport';
+import { exportRoadMeshGlb, exportRoadMeshObj, exportRoadMeshRobloxPackage } from './lib/meshExport';
 import {
   COLORS, ROAD_NETWORK_SCHEMA, ROAD_NETWORK_VERSION,
   sanitizeMeshResolution, DEFAULTS
@@ -270,6 +270,15 @@ export default function App() {
     } catch (err) {
       console.error(err);
       alert('Failed to export GLB. Check the browser console for details.');
+    }
+  };
+
+  const handleExportRoblox = async () => {
+    try {
+      await exportRoadMeshRobloxPackage(buildCurrentMesh());
+    } catch (err) {
+      console.error(err);
+      alert('Failed to export Roblox mesh package. Check the browser console for details.');
     }
   };
 
@@ -1876,6 +1885,7 @@ export default function App() {
         handleExport={handleExport}
         handleExportObj={handleExportObj}
         handleExportGlb={handleExportGlb}
+        handleExportRoblox={handleExportRoblox}
         showControlPoints={showControlPoints}
         setShowControlPoints={setShowControlPoints}
         is3DMode={is3DMode}

--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -7,6 +7,8 @@ import ThreeScene from './ThreeScene';
 import Sidebar from './components/Sidebar';
 import Header from './components/Header';
 import { drawNetwork2D } from './lib/render2d';
+import { buildNetworkMesh } from './lib/meshing';
+import { exportRoadMeshGlb, exportRoadMeshObj } from './lib/meshExport';
 import {
   COLORS, ROAD_NETWORK_SCHEMA, ROAD_NETWORK_VERSION,
   sanitizeMeshResolution, DEFAULTS
@@ -247,6 +249,28 @@ export default function App() {
     a.download = 'network.json';
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const buildCurrentMesh = () => buildNetworkMesh(
+    nodes,
+    edges,
+    chamferAngle,
+    meshResolution,
+    laneWidth,
+    polygonFills
+  );
+
+  const handleExportObj = () => {
+    exportRoadMeshObj(buildCurrentMesh());
+  };
+
+  const handleExportGlb = async () => {
+    try {
+      await exportRoadMeshGlb(buildCurrentMesh());
+    } catch (err) {
+      console.error(err);
+      alert('Failed to export GLB. Check the browser console for details.');
+    }
   };
 
   const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1850,6 +1874,8 @@ export default function App() {
         setIsSidebarOpen={setIsSidebarOpen}
         handleImport={handleImport}
         handleExport={handleExport}
+        handleExportObj={handleExportObj}
+        handleExportGlb={handleExportGlb}
         showControlPoints={showControlPoints}
         setShowControlPoints={setShowControlPoints}
         is3DMode={is3DMode}

--- a/tools/intersection-visualizer/src/components/Header.tsx
+++ b/tools/intersection-visualizer/src/components/Header.tsx
@@ -8,6 +8,7 @@ interface HeaderProps {
   handleExport: () => void;
   handleExportObj: () => void;
   handleExportGlb: () => void;
+  handleExportRoblox: () => void;
   showControlPoints: boolean;
   setShowControlPoints: (v: boolean) => void;
   is3DMode: boolean;
@@ -23,6 +24,7 @@ export default function Header({
   handleExport,
   handleExportObj,
   handleExportGlb,
+  handleExportRoblox,
   showControlPoints,
   setShowControlPoints,
   is3DMode,
@@ -88,6 +90,14 @@ export default function Header({
         >
           <Download className="w-4 h-4" />
           <span className="hidden lg:inline">GLB</span>
+        </button>
+        <button
+          onClick={handleExportRoblox}
+          className="p-2 lg:px-3 lg:py-1.5 border rounded text-sm font-semibold flex items-center gap-2 transition-colors border-slate-700 hover:bg-slate-800 text-slate-300"
+          title="Export Roblox GLB and Manifest"
+        >
+          <Download className="w-4 h-4" />
+          <span className="hidden lg:inline">Roblox</span>
         </button>
         <div className="w-px h-6 bg-slate-700 hidden sm:block mx-1"></div>
         <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-300 font-medium hover:text-white sm:mr-2">

--- a/tools/intersection-visualizer/src/components/Header.tsx
+++ b/tools/intersection-visualizer/src/components/Header.tsx
@@ -6,6 +6,8 @@ interface HeaderProps {
   setIsSidebarOpen: (v: boolean) => void;
   handleImport: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleExport: () => void;
+  handleExportObj: () => void;
+  handleExportGlb: () => void;
   showControlPoints: boolean;
   setShowControlPoints: (v: boolean) => void;
   is3DMode: boolean;
@@ -19,6 +21,8 @@ export default function Header({
   setIsSidebarOpen,
   handleImport,
   handleExport,
+  handleExportObj,
+  handleExportGlb,
   showControlPoints,
   setShowControlPoints,
   is3DMode,
@@ -68,6 +72,22 @@ export default function Header({
         >
           <Download className="w-4 h-4" />
           <span className="hidden xl:inline">Export</span>
+        </button>
+        <button
+          onClick={handleExportObj}
+          className="p-2 lg:px-3 lg:py-1.5 border rounded text-sm font-semibold flex items-center gap-2 transition-colors border-slate-700 hover:bg-slate-800 text-slate-300"
+          title="Export OBJ Mesh"
+        >
+          <Download className="w-4 h-4" />
+          <span className="hidden lg:inline">OBJ</span>
+        </button>
+        <button
+          onClick={handleExportGlb}
+          className="p-2 lg:px-3 lg:py-1.5 border rounded text-sm font-semibold flex items-center gap-2 transition-colors border-slate-700 hover:bg-slate-800 text-slate-300"
+          title="Export GLB Mesh"
+        >
+          <Download className="w-4 h-4" />
+          <span className="hidden lg:inline">GLB</span>
         </button>
         <div className="w-px h-6 bg-slate-700 hidden sm:block mx-1"></div>
         <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-300 font-medium hover:text-white sm:mr-2">

--- a/tools/intersection-visualizer/src/components/three/ActualMesh.tsx
+++ b/tools/intersection-visualizer/src/components/three/ActualMesh.tsx
@@ -1,30 +1,11 @@
 import React, { useMemo } from 'react';
 import * as THREE from 'three';
 import { Point } from '../../lib/types';
+import { createTriangleGeometry } from '../../lib/meshExport';
 
 export function ActualMesh({ mesh, showMesh, debugOptions }: { mesh: any, showMesh: boolean, debugOptions?: any }) {
   const createGeo = (triangles: Point[][]) => {
-    const points: THREE.Vector3[] = [];
-    const uvs: number[] = [];
-    triangles.forEach(tri => {
-      if (tri.length === 3) {
-        // Render the actual flat mesh triangles
-        const p0 = new THREE.Vector3(tri[0].x, tri[0].z ?? 4, tri[0].y);
-        const p1 = new THREE.Vector3(tri[1].x, tri[1].z ?? 4, tri[1].y);
-        const p2 = new THREE.Vector3(tri[2].x, tri[2].z ?? 4, tri[2].y);
-        points.push(p0, p1, p2);
-
-        uvs.push(tri[0].u ?? 0, tri[0].v ?? 0);
-        uvs.push(tri[1].u ?? 0, tri[1].v ?? 0);
-        uvs.push(tri[2].u ?? 0, tri[2].v ?? 0);
-      }
-    });
-    const geo = new THREE.BufferGeometry().setFromPoints(points);
-    if (uvs.length > 0) {
-      geo.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
-    }
-    geo.computeVertexNormals();
-    return geo;
+    return createTriangleGeometry(triangles);
   };
 
   const dashedMap = useMemo(() => {

--- a/tools/intersection-visualizer/src/lib/meshExport.ts
+++ b/tools/intersection-visualizer/src/lib/meshExport.ts
@@ -1,0 +1,135 @@
+import * as THREE from 'three';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
+import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js';
+import { MeshData, Point, Triangle } from './types';
+
+type MeshLayer = {
+  name: string;
+  triangles: Triangle[];
+  color: string;
+  yOffset?: number;
+  opacity?: number;
+};
+
+export function createTriangleGeometry(triangles: Point[][]): THREE.BufferGeometry {
+  const positions: number[] = [];
+  const uvs: number[] = [];
+
+  triangles.forEach((tri) => {
+    if (tri.length !== 3) return;
+
+    tri.forEach((point) => {
+      positions.push(point.x, point.z ?? 4, point.y);
+      uvs.push(point.u ?? 0, point.v ?? 0);
+    });
+  });
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+
+  if (uvs.length > 0) {
+    geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+  }
+
+  geometry.computeVertexNormals();
+  geometry.computeBoundingBox();
+  geometry.computeBoundingSphere();
+  return geometry;
+}
+
+function createMaterial(name: string, color: string, opacity = 1) {
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    side: THREE.DoubleSide,
+    transparent: opacity < 1,
+    opacity,
+  });
+  material.name = name;
+  return material;
+}
+
+function addLayer(group: THREE.Group, layer: MeshLayer) {
+  if (layer.triangles.length === 0) return;
+
+  const mesh = new THREE.Mesh(
+    createTriangleGeometry(layer.triangles),
+    createMaterial(layer.name, layer.color, layer.opacity)
+  );
+  mesh.name = layer.name;
+  mesh.position.y = layer.yOffset ?? 0;
+  group.add(mesh);
+}
+
+export function createRoadMeshExportGroup(meshData: MeshData): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'Cab87RoadMesh';
+
+  const layers: MeshLayer[] = [
+    { name: 'Roads', triangles: meshData.roadTriangles, color: '#1e293b' },
+    { name: 'Junctions', triangles: meshData.hubTriangles, color: '#1e293b', yOffset: 0.05 },
+    { name: 'Crosswalks', triangles: meshData.crosswalkTriangles, color: '#334155', yOffset: 0.1 },
+    { name: 'Sidewalks', triangles: meshData.sidewalkTriangles, color: '#94a3b8', yOffset: 0.15 },
+    { name: 'DashedLaneLines', triangles: meshData.dashedLineTriangles, color: '#ffffff' },
+    { name: 'SolidLaneLines', triangles: meshData.solidLineTriangles, color: '#eab308' },
+  ];
+
+  layers.forEach((layer) => addLayer(group, layer));
+
+  meshData.polygonTriangles.forEach((polygonGroup, index) => {
+    addLayer(group, {
+      name: `PolygonFill_${index + 1}`,
+      triangles: polygonGroup.triangles,
+      color: polygonGroup.color,
+      yOffset: -1.5,
+      opacity: 0.7,
+    });
+  });
+
+  group.updateMatrixWorld(true);
+  return group;
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function disposeObject(root: THREE.Object3D) {
+  root.traverse((object) => {
+    if (!(object instanceof THREE.Mesh)) return;
+    object.geometry.dispose();
+
+    const materials = Array.isArray(object.material) ? object.material : [object.material];
+    materials.forEach((material) => material.dispose());
+  });
+}
+
+export function exportRoadMeshObj(meshData: MeshData, filename = 'cab87-road-mesh.obj') {
+  const group = createRoadMeshExportGroup(meshData);
+  const output = new OBJExporter().parse(group);
+  downloadBlob(new Blob([output], { type: 'text/plain;charset=utf-8' }), filename);
+  disposeObject(group);
+}
+
+export async function exportRoadMeshGlb(meshData: MeshData, filename = 'cab87-road-mesh.glb') {
+  const group = createRoadMeshExportGroup(meshData);
+  const result = await new GLTFExporter().parseAsync(group, {
+    binary: true,
+    onlyVisible: true,
+    trs: false,
+    forceIndices: true,
+  });
+
+  if (!(result instanceof ArrayBuffer)) {
+    throw new Error('GLB export did not produce binary output.');
+  }
+
+  downloadBlob(new Blob([result], { type: 'model/gltf-binary' }), filename);
+  disposeObject(group);
+}

--- a/tools/intersection-visualizer/src/lib/meshExport.ts
+++ b/tools/intersection-visualizer/src/lib/meshExport.ts
@@ -11,7 +11,39 @@ type MeshLayer = {
   opacity?: number;
 };
 
-export function createTriangleGeometry(triangles: Point[][]): THREE.BufferGeometry {
+type RobloxChunkLayer = {
+  layer: string;
+  baseName: string;
+  surfaceType: string;
+  triangles: Triangle[];
+  color: string;
+  material: string;
+  yOffset?: number;
+  kind?: 'surface' | 'marking';
+  includeCollision?: boolean;
+  collisionBaseName?: string;
+};
+
+type Bounds = {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+  size: { x: number; y: number; z: number };
+};
+
+type TriangleBucket = {
+  chunkX: number;
+  chunkZ: number;
+  triangles: Triangle[];
+};
+
+const ROBLOX_MANIFEST_SCHEMA = 'cab87-road-mesh-manifest';
+const ROBLOX_MANIFEST_VERSION = 1;
+const ROBLOX_CHUNK_SIZE = 768;
+const ROBLOX_MAX_SURFACE_TRIANGLES = 6000;
+const ROBLOX_MAX_COLLISION_INPUT_TRIANGLES = 900;
+const ROBLOX_COLLISION_THICKNESS = 0.2;
+
+export function createTriangleGeometry(triangles: Point[][], yOffset = 0): THREE.BufferGeometry {
   const positions: number[] = [];
   const uvs: number[] = [];
 
@@ -19,15 +51,19 @@ export function createTriangleGeometry(triangles: Point[][]): THREE.BufferGeomet
     if (tri.length !== 3) return;
 
     tri.forEach((point) => {
-      positions.push(point.x, point.z ?? 4, point.y);
+      positions.push(point.x, (point.z ?? 4) + yOffset, point.y);
       uvs.push(point.u ?? 0, point.v ?? 0);
     });
   });
 
+  return createGeometryFromPositions(positions, uvs);
+}
+
+function createGeometryFromPositions(positions: number[], uvs?: number[]): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
 
-  if (uvs.length > 0) {
+  if (uvs && uvs.length > 0) {
     geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
   }
 
@@ -35,6 +71,41 @@ export function createTriangleGeometry(triangles: Point[][]): THREE.BufferGeomet
   geometry.computeBoundingBox();
   geometry.computeBoundingSphere();
   return geometry;
+}
+
+function addTrianglePositions(positions: number[], a: THREE.Vector3, b: THREE.Vector3, c: THREE.Vector3) {
+  positions.push(a.x, a.y, a.z, b.x, b.y, b.z, c.x, c.y, c.z);
+}
+
+function addQuadPositions(positions: number[], a: THREE.Vector3, b: THREE.Vector3, c: THREE.Vector3, d: THREE.Vector3) {
+  addTrianglePositions(positions, a, b, c);
+  addTrianglePositions(positions, a, c, d);
+}
+
+function toVector(point: Point, yOffset = 0) {
+  return new THREE.Vector3(point.x, (point.z ?? 4) + yOffset, point.y);
+}
+
+function createCollisionGeometry(triangles: Triangle[], yOffset = 0, thickness = ROBLOX_COLLISION_THICKNESS) {
+  const positions: number[] = [];
+  const bottomOffset = new THREE.Vector3(0, -Math.max(thickness, 0.05), 0);
+
+  triangles.forEach((triangle) => {
+    const a = toVector(triangle[0], yOffset);
+    const b = toVector(triangle[1], yOffset);
+    const c = toVector(triangle[2], yOffset);
+    const ab = a.clone().add(bottomOffset);
+    const bb = b.clone().add(bottomOffset);
+    const cb = c.clone().add(bottomOffset);
+
+    addTrianglePositions(positions, a, b, c);
+    addTrianglePositions(positions, ab, cb, bb);
+    addQuadPositions(positions, a, ab, bb, b);
+    addQuadPositions(positions, b, bb, cb, c);
+    addQuadPositions(positions, c, cb, ab, a);
+  });
+
+  return createGeometryFromPositions(positions);
 }
 
 function createMaterial(name: string, color: string, opacity = 1) {
@@ -48,6 +119,76 @@ function createMaterial(name: string, color: string, opacity = 1) {
   return material;
 }
 
+function computeBounds(geometry: THREE.BufferGeometry): Bounds {
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox ?? new THREE.Box3();
+  const size = new THREE.Vector3();
+  box.getSize(size);
+  return {
+    min: { x: box.min.x, y: box.min.y, z: box.min.z },
+    max: { x: box.max.x, y: box.max.y, z: box.max.z },
+    size: { x: size.x, y: size.y, z: size.z },
+  };
+}
+
+function safeName(value: string) {
+  return value.replace(/[^A-Za-z0-9_]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '');
+}
+
+function chunkLabel(value: number) {
+  return value < 0 ? `n${Math.abs(value)}` : `p${value}`;
+}
+
+function chunkName(baseName: string, bucket: TriangleBucket, batchIndex: number) {
+  return safeName(
+    `${baseName}_x${chunkLabel(bucket.chunkX)}_z${chunkLabel(bucket.chunkZ)}_${String(batchIndex + 1).padStart(2, '0')}`
+  );
+}
+
+function triangleCenter(triangle: Triangle) {
+  return {
+    x: (triangle[0].x + triangle[1].x + triangle[2].x) / 3,
+    z: (triangle[0].y + triangle[1].y + triangle[2].y) / 3,
+  };
+}
+
+function bucketTrianglesByCenter(triangles: Triangle[], chunkSize: number) {
+  const bucketsByKey = new Map<string, TriangleBucket>();
+
+  triangles.forEach((triangle) => {
+    const center = triangleCenter(triangle);
+    const chunkX = Math.floor(center.x / chunkSize);
+    const chunkZ = Math.floor(center.z / chunkSize);
+    const key = `${chunkX}:${chunkZ}`;
+    let bucket = bucketsByKey.get(key);
+    if (!bucket) {
+      bucket = { chunkX, chunkZ, triangles: [] };
+      bucketsByKey.set(key, bucket);
+    }
+    bucket.triangles.push(triangle);
+  });
+
+  return [...bucketsByKey.values()].sort((a, b) => {
+    if (a.chunkX === b.chunkX) return a.chunkZ - b.chunkZ;
+    return a.chunkX - b.chunkX;
+  });
+}
+
+function triangleBatches(triangles: Triangle[], maxTriangles: number) {
+  const batches: Triangle[][] = [];
+  const limit = Math.max(Math.floor(maxTriangles), 1);
+  for (let index = 0; index < triangles.length; index += limit) {
+    batches.push(triangles.slice(index, index + limit));
+  }
+  return batches;
+}
+
+function createMeshFromGeometry(name: string, geometry: THREE.BufferGeometry, color: string, opacity = 1) {
+  const mesh = new THREE.Mesh(geometry, createMaterial(name, color, opacity));
+  mesh.name = name;
+  return mesh;
+}
+
 function addLayer(group: THREE.Group, layer: MeshLayer) {
   if (layer.triangles.length === 0) return;
 
@@ -58,6 +199,88 @@ function addLayer(group: THREE.Group, layer: MeshLayer) {
   mesh.name = layer.name;
   mesh.position.y = layer.yOffset ?? 0;
   group.add(mesh);
+}
+
+function getRobloxLayers(meshData: MeshData): RobloxChunkLayer[] {
+  const layers: RobloxChunkLayer[] = [
+    {
+      layer: 'roads',
+      baseName: 'RoadSurface',
+      collisionBaseName: 'RoadCollision',
+      surfaceType: 'road',
+      triangles: meshData.roadTriangles,
+      color: '#1e293b',
+      material: 'Asphalt',
+      includeCollision: true,
+    },
+    {
+      layer: 'junctions',
+      baseName: 'RoadJunctionSurface',
+      collisionBaseName: 'RoadJunctionCollision',
+      surfaceType: 'road',
+      triangles: meshData.hubTriangles,
+      color: '#1e293b',
+      material: 'Asphalt',
+      yOffset: 0.05,
+      includeCollision: true,
+    },
+    {
+      layer: 'sidewalks',
+      baseName: 'SidewalkSurface',
+      collisionBaseName: 'SidewalkCollision',
+      surfaceType: 'sidewalk',
+      triangles: meshData.sidewalkTriangles,
+      color: '#94a3b8',
+      material: 'Concrete',
+      yOffset: 0.15,
+      includeCollision: true,
+    },
+    {
+      layer: 'crosswalks',
+      baseName: 'CrosswalkSurface',
+      collisionBaseName: 'CrosswalkCollision',
+      surfaceType: 'crosswalk',
+      triangles: meshData.crosswalkTriangles,
+      color: '#334155',
+      material: 'SmoothPlastic',
+      yOffset: 0.1,
+      includeCollision: true,
+    },
+    {
+      layer: 'dashedLaneLines',
+      baseName: 'DashedLaneLine',
+      surfaceType: 'marking',
+      triangles: meshData.dashedLineTriangles,
+      color: '#ffffff',
+      material: 'SmoothPlastic',
+      kind: 'marking',
+    },
+    {
+      layer: 'solidLaneLines',
+      baseName: 'SolidLaneLine',
+      surfaceType: 'marking',
+      triangles: meshData.solidLineTriangles,
+      color: '#eab308',
+      material: 'SmoothPlastic',
+      kind: 'marking',
+    },
+  ];
+
+  meshData.polygonTriangles.forEach((polygonGroup, index) => {
+    layers.push({
+      layer: `polygonFill_${index + 1}`,
+      baseName: `PolygonFillSurface_${index + 1}`,
+      collisionBaseName: `PolygonFillCollision_${index + 1}`,
+      surfaceType: 'polygonFill',
+      triangles: polygonGroup.triangles,
+      color: polygonGroup.color,
+      material: 'SmoothPlastic',
+      yOffset: -1.5,
+      includeCollision: true,
+    });
+  });
+
+  return layers;
 }
 
 export function createRoadMeshExportGroup(meshData: MeshData): THREE.Group {
@@ -87,6 +310,95 @@ export function createRoadMeshExportGroup(meshData: MeshData): THREE.Group {
 
   group.updateMatrixWorld(true);
   return group;
+}
+
+export function createRobloxRoadMeshExport(meshData: MeshData) {
+  const group = new THREE.Group();
+  group.name = 'Cab87RobloxRoadMesh';
+  const chunks: any[] = [];
+
+  const addChunk = (
+    layer: RobloxChunkLayer,
+    bucket: TriangleBucket,
+    batch: Triangle[],
+    batchIndex: number,
+    kind: 'surface' | 'collision' | 'marking'
+  ) => {
+    const isCollision = kind === 'collision';
+    const name = chunkName(isCollision ? (layer.collisionBaseName ?? `${layer.baseName}Collision`) : layer.baseName, bucket, batchIndex);
+    const yOffset = layer.yOffset ?? 0;
+    const geometry = isCollision
+      ? createCollisionGeometry(batch, yOffset, ROBLOX_COLLISION_THICKNESS)
+      : createTriangleGeometry(batch, yOffset);
+    const actualTriangleCount = Math.floor((geometry.getAttribute('position')?.count ?? 0) / 3);
+    const mesh = createMeshFromGeometry(name, geometry, isCollision ? '#38bdf8' : layer.color, isCollision ? 0.18 : 1);
+    group.add(mesh);
+
+    chunks.push({
+      name,
+      kind,
+      layer: layer.layer,
+      surfaceType: layer.surfaceType,
+      material: layer.material,
+      color: layer.color,
+      transparency: isCollision ? 1 : 0,
+      canCollide: isCollision,
+      canQuery: isCollision,
+      canTouch: false,
+      castShadow: false,
+      driveSurface: isCollision,
+      collisionFidelity: isCollision ? 'PreciseConvexDecomposition' : 'Box',
+      triangleCount: actualTriangleCount,
+      inputTriangleCount: batch.length,
+      chunkKey: `${bucket.chunkX}:${bucket.chunkZ}`,
+      chunkX: bucket.chunkX,
+      chunkZ: bucket.chunkZ,
+      batchIndex: batchIndex + 1,
+      bounds: computeBounds(geometry),
+    });
+  };
+
+  getRobloxLayers(meshData).forEach((layer) => {
+    if (layer.triangles.length === 0) return;
+
+    const surfaceMaxTriangles = layer.kind === 'marking'
+      ? ROBLOX_MAX_SURFACE_TRIANGLES
+      : ROBLOX_MAX_SURFACE_TRIANGLES;
+    bucketTrianglesByCenter(layer.triangles, ROBLOX_CHUNK_SIZE).forEach((bucket) => {
+      triangleBatches(bucket.triangles, surfaceMaxTriangles).forEach((batch, batchIndex) => {
+        addChunk(layer, bucket, batch, batchIndex, layer.kind ?? 'surface');
+      });
+
+      if (layer.includeCollision) {
+        triangleBatches(bucket.triangles, ROBLOX_MAX_COLLISION_INPUT_TRIANGLES).forEach((batch, batchIndex) => {
+          addChunk(layer, bucket, batch, batchIndex, 'collision');
+        });
+      }
+    });
+  });
+
+  group.updateMatrixWorld(true);
+
+  const manifest = {
+    schema: ROBLOX_MANIFEST_SCHEMA,
+    version: ROBLOX_MANIFEST_VERSION,
+    settings: {
+      chunkSize: ROBLOX_CHUNK_SIZE,
+      maxSurfaceTriangles: ROBLOX_MAX_SURFACE_TRIANGLES,
+      maxCollisionInputTriangles: ROBLOX_MAX_COLLISION_INPUT_TRIANGLES,
+      collisionThickness: ROBLOX_COLLISION_THICKNESS,
+    },
+    counts: {
+      chunks: chunks.length,
+      surfaceChunks: chunks.filter((chunk) => chunk.kind === 'surface').length,
+      collisionChunks: chunks.filter((chunk) => chunk.kind === 'collision').length,
+      markingChunks: chunks.filter((chunk) => chunk.kind === 'marking').length,
+      triangles: chunks.reduce((sum, chunk) => sum + chunk.triangleCount, 0),
+    },
+    chunks,
+  };
+
+  return { group, manifest };
 }
 
 function downloadBlob(blob: Blob, filename: string) {
@@ -131,5 +443,29 @@ export async function exportRoadMeshGlb(meshData: MeshData, filename = 'cab87-ro
   }
 
   downloadBlob(new Blob([result], { type: 'model/gltf-binary' }), filename);
+  disposeObject(group);
+}
+
+export async function exportRoadMeshRobloxPackage(
+  meshData: MeshData,
+  basename = 'cab87-road-mesh'
+) {
+  const { group, manifest } = createRobloxRoadMeshExport(meshData);
+  const result = await new GLTFExporter().parseAsync(group, {
+    binary: true,
+    onlyVisible: true,
+    trs: false,
+    forceIndices: true,
+  });
+
+  if (!(result instanceof ArrayBuffer)) {
+    throw new Error('Roblox GLB export did not produce binary output.');
+  }
+
+  downloadBlob(new Blob([result], { type: 'model/gltf-binary' }), `${basename}.glb`);
+  downloadBlob(
+    new Blob([JSON.stringify(manifest, null, 2)], { type: 'application/json' }),
+    `${basename}.manifest.json`
+  );
   disposeObject(group);
 }

--- a/tools/intersection-visualizer/src/lib/meshExport.ts
+++ b/tools/intersection-visualizer/src/lib/meshExport.ts
@@ -43,7 +43,7 @@ const ROBLOX_MAX_SURFACE_TRIANGLES = 6000;
 const ROBLOX_MAX_COLLISION_INPUT_TRIANGLES = 900;
 const ROBLOX_COLLISION_THICKNESS = 0.2;
 
-export function createTriangleGeometry(triangles: Point[][], yOffset = 0): THREE.BufferGeometry {
+export function createTriangleGeometry(triangles: Point[][], yOffset = 0, defaultY = 4): THREE.BufferGeometry {
   const positions: number[] = [];
   const uvs: number[] = [];
 
@@ -51,7 +51,7 @@ export function createTriangleGeometry(triangles: Point[][], yOffset = 0): THREE
     if (tri.length !== 3) return;
 
     tri.forEach((point) => {
-      positions.push(point.x, (point.z ?? 4) + yOffset, point.y);
+      positions.push(point.x, (point.z ?? defaultY) + yOffset, point.y);
       uvs.push(point.u ?? 0, point.v ?? 0);
     });
   });
@@ -82,18 +82,23 @@ function addQuadPositions(positions: number[], a: THREE.Vector3, b: THREE.Vector
   addTrianglePositions(positions, a, c, d);
 }
 
-function toVector(point: Point, yOffset = 0) {
-  return new THREE.Vector3(point.x, (point.z ?? 4) + yOffset, point.y);
+function toVector(point: Point, yOffset = 0, defaultY = 4) {
+  return new THREE.Vector3(point.x, (point.z ?? defaultY) + yOffset, point.y);
 }
 
-function createCollisionGeometry(triangles: Triangle[], yOffset = 0, thickness = ROBLOX_COLLISION_THICKNESS) {
+function createCollisionGeometry(
+  triangles: Triangle[],
+  yOffset = 0,
+  thickness = ROBLOX_COLLISION_THICKNESS,
+  defaultY = 4
+) {
   const positions: number[] = [];
   const bottomOffset = new THREE.Vector3(0, -Math.max(thickness, 0.05), 0);
 
   triangles.forEach((triangle) => {
-    const a = toVector(triangle[0], yOffset);
-    const b = toVector(triangle[1], yOffset);
-    const c = toVector(triangle[2], yOffset);
+    const a = toVector(triangle[0], yOffset, defaultY);
+    const b = toVector(triangle[1], yOffset, defaultY);
+    const c = toVector(triangle[2], yOffset, defaultY);
     const ab = a.clone().add(bottomOffset);
     const bb = b.clone().add(bottomOffset);
     const cb = c.clone().add(bottomOffset);
@@ -328,8 +333,8 @@ export function createRobloxRoadMeshExport(meshData: MeshData) {
     const name = chunkName(isCollision ? (layer.collisionBaseName ?? `${layer.baseName}Collision`) : layer.baseName, bucket, batchIndex);
     const yOffset = layer.yOffset ?? 0;
     const geometry = isCollision
-      ? createCollisionGeometry(batch, yOffset, ROBLOX_COLLISION_THICKNESS)
-      : createTriangleGeometry(batch, yOffset);
+      ? createCollisionGeometry(batch, yOffset, ROBLOX_COLLISION_THICKNESS, 0)
+      : createTriangleGeometry(batch, yOffset, 0);
     const actualTriangleCount = Math.floor((geometry.getAttribute('position')?.count ?? 0) / 3);
     const mesh = createMeshFromGeometry(name, geometry, isCollision ? '#38bdf8' : layer.color, isCollision ? 0.18 : 1);
     group.add(mesh);


### PR DESCRIPTION
## Summary

Adds an imported-GLB road mesh workflow so large authored road graphs can avoid Studio/runtime `EditableMesh` generation and avoid keeping Roblox's Luau mesher on the critical path.

## Details

- Adds a **Roblox** export in the intersection visualizer that downloads:
  - `cab87-road-mesh.glb`
  - `cab87-road-mesh.manifest.json`
- Splits visual and collision GLB objects by spatial chunk and triangle budget.
- Adds collision mesh objects to the GLB so imported MeshParts can provide runtime drive surfaces.
- Adds **Adopt Imported GLB Mesh** to the Studio plugin.
  - Select an imported GLB model or its MeshParts.
  - Choose the exported manifest JSON.
  - The plugin moves/configures parts into `Cab87RoadEditor/RoadGraphBakedRuntime`.
- Changes graph JSON import to write lightweight graph data without automatically running the Luau bake.
- Updates Play runtime to use adopted imported MeshParts when present, skipping runtime collision meshing and client visual meshing.
- Makes road graph mesher/builder requires lazy in runtime/client code so the imported path no longer needs those modules at startup.
- Updates docs for the new workflow.

## Validation

- `npm run lint`
- `npm run build`
- `rojo build default.project.json --output /tmp/cab87-intersection-mesh-export.rbxlx`
- `git diff --check`

The Vite build completed successfully with the existing large chunk warning.