### PR TITLE
[codex] Fix intersection visualizer mesh handling

### DIFF
--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -159,11 +159,13 @@ export default function App() {
     return minKey;
   };
 
-  const topologyKey = useMemo(() => {
-    const nodeKey = nodes.map(n => n.id).sort().join('|');
-    const edgeKey = edges.map(e => `${e.id}:${e.source}-${e.target || ''}`).sort().join('|');
+  const getTopologyKey = (nextNodes: Node[], nextEdges: Edge[]) => {
+    const nodeKey = nextNodes.map(n => n.id).sort().join('|');
+    const edgeKey = nextEdges.map(e => `${e.id}:${e.source}-${e.target || ''}`).sort().join('|');
     return `${nodeKey}::${edgeKey}`;
-  }, [nodes, edges]);
+  };
+
+  const topologyKey = useMemo(() => getTopologyKey(nodes, edges), [nodes, edges]);
 
   const prevTopologyKey = useRef<string | null>(null);
 
@@ -191,36 +193,21 @@ export default function App() {
               return;
           }
 
-          let bestMatch: typeof prevPolygonFills[number] | null = null;
-          let bestScore = -1;
-
-          validPreviousFills.forEach(pf => {
-             if (usedOldIds.has(pf.id)) return;
-             const sharedCount = pf.points.filter((nid: string) => faceNodes.includes(nid)).length;
-             if (sharedCount > bestScore) {
-                 bestScore = sharedCount;
-                 bestMatch = pf;
-             }
-          });
-
-          // Minimum 2 shared nodes to inherit properties (color, id)
-          if (bestMatch && bestScore >= 2) {
-              usedOldIds.add((bestMatch as any).id);
-              newPolygonFills.push({ id: (bestMatch as any).id, points: faceNodes, color: (bestMatch as any).color });
-          } else {
-              const id = Math.random().toString(36).substring(2, 9);
-              const color = '#10b981'; // default fill color (emerald)
-              newPolygonFills.push({ id, points: faceNodes, color });
-          }
+          const id = Math.random().toString(36).substring(2, 9);
+          const color = '#10b981'; // default fill color (emerald)
+          newPolygonFills.push({ id, points: faceNodes, color });
         });
 
+        const preservedFills = validPreviousFills.filter(pf => !usedOldIds.has(pf.id));
+        const nextPolygonFills = [...newPolygonFills, ...preservedFills];
+
         // Determine if there is actually a change to prevent infinite loops
-        const changed = newPolygonFills.length !== prevPolygonFills.length || newPolygonFills.some((nf) => {
+        const changed = nextPolygonFills.length !== prevPolygonFills.length || nextPolygonFills.some((nf) => {
           const of = prevPolygonFills.find(p => p.id === nf.id);
           return !of || of.color !== nf.color || of.points.length !== nf.points.length || nf.points.some((pointId, index) => pointId !== of.points[index]);
         });
 
-        return changed ? newPolygonFills : prevPolygonFills;
+        return changed ? nextPolygonFills : prevPolygonFills;
       } catch (err) {
         console.error(err);
         return prevPolygonFills;
@@ -296,6 +283,7 @@ export default function App() {
           return;
         }
         if (Array.isArray(data.nodes) && Array.isArray(data.edges)) {
+          prevTopologyKey.current = getTopologyKey(data.nodes, data.edges);
           setNodes(data.nodes);
           setEdges(data.edges);
           if (typeof data.settings?.chamferAngleDeg === 'number') {

--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -168,16 +168,21 @@ export default function App() {
   const topologyKey = useMemo(() => getTopologyKey(nodes, edges), [nodes, edges]);
 
   const prevTopologyKey = useRef<string | null>(null);
+  const prevFaceKeysRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (prevTopologyKey.current === topologyKey) return;
     prevTopologyKey.current = topologyKey;
+    const faces = findClosedAreas(nodes, edges);
+    const currentFaceKeys = new Set(faces.map(getFaceKey));
+    const previousFaceKeys = prevFaceKeysRef.current;
 
     setPolygonFills(prevPolygonFills => {
       try {
         const validNodes = new Set(nodes.map(n => n.id));
         const validPreviousFills = prevPolygonFills.filter(pf => pf.points.every(pid => validNodes.has(pid)));
-        const faces = findClosedAreas(nodes, edges);
+        const previousAutoFills = validPreviousFills.filter(pf => previousFaceKeys.has(getFaceKey(pf.points)));
+        const previousAutoFillIds = new Set(previousAutoFills.map(pf => pf.id));
 
         const newPolygonFills: typeof prevPolygonFills = [];
         const usedOldIds = new Set<string>();
@@ -193,12 +198,30 @@ export default function App() {
               return;
           }
 
-          const id = Math.random().toString(36).substring(2, 9);
-          const color = '#10b981'; // default fill color (emerald)
-          newPolygonFills.push({ id, points: faceNodes, color });
+          let bestMatch: typeof prevPolygonFills[number] | null = null;
+          let bestScore = -1;
+
+          previousAutoFills.forEach(pf => {
+             if (usedOldIds.has(pf.id)) return;
+             const sharedCount = pf.points.filter((nid: string) => faceNodes.includes(nid)).length;
+             if (sharedCount > bestScore) {
+                 bestScore = sharedCount;
+                 bestMatch = pf;
+             }
+          });
+
+          // Migrate old auto-detected fills through topology edits, but do not consume custom fills.
+          if (bestMatch && bestScore >= 2) {
+              usedOldIds.add((bestMatch as any).id);
+              newPolygonFills.push({ id: (bestMatch as any).id, points: faceNodes, color: (bestMatch as any).color });
+          } else {
+              const id = Math.random().toString(36).substring(2, 9);
+              const color = '#10b981'; // default fill color (emerald)
+              newPolygonFills.push({ id, points: faceNodes, color });
+          }
         });
 
-        const preservedFills = validPreviousFills.filter(pf => !usedOldIds.has(pf.id));
+        const preservedFills = validPreviousFills.filter(pf => !usedOldIds.has(pf.id) && !previousAutoFillIds.has(pf.id));
         const nextPolygonFills = [...newPolygonFills, ...preservedFills];
 
         // Determine if there is actually a change to prevent infinite loops
@@ -213,6 +236,7 @@ export default function App() {
         return prevPolygonFills;
       }
     });
+    prevFaceKeysRef.current = currentFaceKeys;
   }, [topologyKey, nodes, edges, deletedFaces]);
 
   const handleExport = () => {
@@ -284,6 +308,7 @@ export default function App() {
         }
         if (Array.isArray(data.nodes) && Array.isArray(data.edges)) {
           prevTopologyKey.current = getTopologyKey(data.nodes, data.edges);
+          prevFaceKeysRef.current = new Set(findClosedAreas(data.nodes, data.edges).map(getFaceKey));
           setNodes(data.nodes);
           setEdges(data.edges);
           if (typeof data.settings?.chamferAngleDeg === 'number') {

--- a/tools/intersection-visualizer/src/components/Sidebar.tsx
+++ b/tools/intersection-visualizer/src/components/Sidebar.tsx
@@ -2,8 +2,12 @@ import React, { useState } from 'react';
 import { X, ChevronDown, ChevronRight, Copy, ClipboardPaste, Trash2 } from 'lucide-react';
 import { Node, Edge } from '../lib/types';
 import { sanitizeMeshResolution } from '../lib/constants';
+import { getEdgeClearance } from '../lib/junctions';
+import { isTrueJunction } from '../lib/network';
 
 import { DEFAULTS } from '../lib/constants';
+
+const JUNCTION_HANDLE_EXTRA_LENGTH = 6;
 
 interface SidebarProps {
   isSidebarOpen: boolean;
@@ -129,6 +133,87 @@ export default function Sidebar({
       sidewalk: Math.max(0, Math.round((e.sidewalk ?? DEFAULTS.sidewalkWidth) * scale)),
     })));
     setGlobalScaleSidewalks("1.0");
+  };
+
+  const normalizeJunctionHandles = () => {
+    const nodeById = new Map(nodes.map(node => [node.id, node]));
+
+    type PointLike = { x: number; y: number; z?: number };
+
+    const getDirection = (from: PointLike, to?: PointLike | null) => {
+      if (!to) return null;
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const len = Math.hypot(dx, dy);
+      if (len < 0.001) return null;
+      return { x: dx / len, y: dy / len };
+    };
+
+    type Endpoint = {
+      node: Node;
+      handleIndex: number;
+      isSource: boolean;
+      fallbackPoint?: PointLike;
+    };
+
+    const normalizeEndpoint = (edge: Edge, nextPoints: Edge['points'], allEdges: Edge[], endpoint: Endpoint) => {
+      const handle = nextPoints[endpoint.handleIndex];
+      if (!handle) return false;
+
+      const clearance = Math.max(0, getEdgeClearance(endpoint.node.id, edge, endpoint.isSource, nodes, allEdges, chamferAngle));
+      const crosswalkLength = isTrueJunction(endpoint.node.id, nodes, allEdges) ? DEFAULTS.crosswalkLength : 0;
+      const minLength = clearance + crosswalkLength + JUNCTION_HANDLE_EXTRA_LENGTH;
+      if (minLength <= JUNCTION_HANDLE_EXTRA_LENGTH) return false;
+
+      const hx = handle.x - endpoint.node.point.x;
+      const hy = handle.y - endpoint.node.point.y;
+      const handleLength = Math.hypot(hx, hy);
+      const fallbackDir = getDirection(endpoint.node.point, endpoint.fallbackPoint);
+      let dir = handleLength > 0.001 ? { x: hx / handleLength, y: hy / handleLength } : fallbackDir;
+      let shouldNormalize = handleLength < minLength;
+
+      if (dir && fallbackDir && dir.x * fallbackDir.x + dir.y * fallbackDir.y < 0) {
+        dir = fallbackDir;
+        shouldNormalize = true;
+      }
+
+      if (!dir || !shouldNormalize) return false;
+
+      nextPoints[endpoint.handleIndex] = {
+        ...handle,
+        x: endpoint.node.point.x + dir.x * minLength,
+        y: endpoint.node.point.y + dir.y * minLength,
+        z: handle.z ?? endpoint.node.point.z ?? 4,
+      };
+      return true;
+    };
+
+    setEdges(prev => prev.map(edge => {
+      const sourceNode = nodeById.get(edge.source);
+      if (!sourceNode || edge.points.length === 0) return edge;
+
+      const targetNode = edge.target ? nodeById.get(edge.target) : null;
+      const nextPoints = edge.points.map(point => ({ ...point }));
+      let changed = false;
+
+      changed = normalizeEndpoint(edge, nextPoints, prev, {
+        node: sourceNode,
+        handleIndex: 0,
+        isSource: true,
+        fallbackPoint: edge.points.length >= 3 ? edge.points[2] : (targetNode?.point ?? edge.points[1]),
+      }) || changed;
+
+      if (targetNode && edge.points.length > 1) {
+        changed = normalizeEndpoint(edge, nextPoints, prev, {
+          node: targetNode,
+          handleIndex: edge.points.length - 1,
+          isSource: false,
+          fallbackPoint: edge.points.length >= 3 ? edge.points[edge.points.length - 3] : sourceNode.point,
+        }) || changed;
+      }
+
+      return changed ? { ...edge, points: nextPoints } : edge;
+    }));
   };
 
   const handleFlipEdge = (id: string) => {
@@ -697,6 +782,14 @@ export default function Sidebar({
                   />
                   <button onClick={applyGlobalScaleSidewalks} className="flex-1 px-2 py-1 bg-purple-600 hover:bg-purple-500 text-white rounded text-xs font-semibold">Apply Scale</button>
                 </div>
+              </div>
+              <div className="pt-2 border-t border-slate-800">
+                <button
+                  onClick={normalizeJunctionHandles}
+                  className="w-full px-3 py-1.5 bg-slate-700 hover:bg-slate-600 text-white rounded text-xs font-semibold flex items-center justify-center transition-colors"
+                >
+                  Normalize Junction Handles
+                </button>
               </div>
             </div>
           )}

--- a/tools/intersection-visualizer/src/lib/constants.ts
+++ b/tools/intersection-visualizer/src/lib/constants.ts
@@ -5,6 +5,7 @@ export const ROAD_NETWORK_VERSION = 1;
 export const DEFAULTS = {
   roadWidth: 60,
   sidewalkWidth: 24,
+  crosswalkLength: 14,
   laneWidth: 30,
   softSelectionRadius: 200,
   chamferAngle: 70,

--- a/tools/intersection-visualizer/src/lib/meshing.ts
+++ b/tools/intersection-visualizer/src/lib/meshing.ts
@@ -14,6 +14,11 @@ export function getEdgeBases(node: Node, sourceNode: Node, edge: Edge, isSource:
   return [bases[0], bases[1]];
 }
 
+function topFacingTriangle(a: Point, b: Point, c: Point): Triangle {
+  const signedArea = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+  return signedArea > 0 ? [a, c, b] : [a, b, c];
+}
+
 export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: number, meshResolution: number = DEFAULTS.meshResolution, laneWidth: number = DEFAULTS.laneWidth, polygonFills: PolygonFill[] = []): MeshData {
   const mesh: MeshData = {
     vertices: [],
@@ -159,16 +164,24 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
           hubPolygon.push(sL);
           if (!node.ignoreMeshing) {
             mesh.sidewalkPolygons.push({ polygon: [obL, bL, sL, osL] });
-            mesh.sidewalkTriangles.push([bL, sL, osL], [bL, osL, obL]);
-            mesh.triangles.push([bL, sL, osL], [bL, osL, obL]);
+            const smoothingTriangles = [
+              topFacingTriangle(bL, sL, osL),
+              topFacingTriangle(bL, osL, obL),
+            ];
+            mesh.sidewalkTriangles.push(...smoothingTriangles);
+            mesh.triangles.push(...smoothingTriangles);
           }
         }
         if (distR < maxDist - 0.01) {
           hubPolygon.push(sR);
           if (!node.ignoreMeshing) {
             mesh.sidewalkPolygons.push({ polygon: [osR, sR, bR, obR] });
-            mesh.sidewalkTriangles.push([bR, osR, sR], [bR, obR, osR]);
-            mesh.triangles.push([bR, osR, sR], [bR, obR, osR]);
+            const smoothingTriangles = [
+              topFacingTriangle(bR, osR, sR),
+              topFacingTriangle(bR, obR, osR),
+            ];
+            mesh.sidewalkTriangles.push(...smoothingTriangles);
+            mesh.triangles.push(...smoothingTriangles);
           }
         }
 
@@ -192,8 +205,8 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
       for (let i = 0; i < hubPolygon.length; i++) {
         const p1 = hubPolygon[i];
         const p2 = hubPolygon[(i + 1) % hubPolygon.length];
-        mesh.hubTriangles.push([node.point, p1, p2]);
-        mesh.triangles.push([node.point, p1, p2]);
+        mesh.hubTriangles.push([node.point, p2, p1]);
+        mesh.triangles.push([node.point, p2, p1]);
       }
 
       for (let i = 0; i < corners.length; i++) {
@@ -205,10 +218,12 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
         mesh.sidewalkPolygons.push({ polygon: poly });
 
         for (let j = 0; j < innerPts.length - 1; j++) {
-          mesh.sidewalkTriangles.push([innerPts[j], outerPts[j], outerPts[j+1]]);
-          mesh.sidewalkTriangles.push([innerPts[j], outerPts[j+1], innerPts[j+1]]);
-          mesh.triangles.push([innerPts[j], outerPts[j], outerPts[j+1]]);
-          mesh.triangles.push([innerPts[j], outerPts[j+1], innerPts[j+1]]);
+          const smoothingTriangles = [
+            topFacingTriangle(innerPts[j], outerPts[j], outerPts[j+1]),
+            topFacingTriangle(innerPts[j], outerPts[j+1], innerPts[j+1]),
+          ];
+          mesh.sidewalkTriangles.push(...smoothingTriangles);
+          mesh.triangles.push(...smoothingTriangles);
         }
       }
     }
@@ -289,7 +304,7 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
       outerRightPoints.push({ x: p2.x + right.x * OW_R, y: p2.y + right.y * OW_R, z: p2.z });
     }
 
-    const cwWidth = 14;
+    const cwWidth = DEFAULTS.crosswalkLength;
 
     if (sourceBases && outerSourceBases) {
        let [bL, bR] = sourceBases;
@@ -353,12 +368,12 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
                mesh.sidewalkPolygons.push({ polygon: [otbL, tbL, new_tbL, new_otbL] });
                mesh.sidewalkPolygons.push({ polygon: [tbR, otbR, new_otbR, new_tbR] });
 
-               mesh.crosswalkTriangles.push([tbL, tbR, new_tbR], [tbL, new_tbR, new_tbL]);
-               mesh.sidewalkTriangles.push([otbL, tbL, new_tbL], [otbL, new_tbL, new_otbL]);
-               mesh.sidewalkTriangles.push([tbR, otbR, new_otbR], [tbR, new_otbR, new_tbR]);
-               mesh.triangles.push([tbL, tbR, new_tbR], [tbL, new_tbR, new_tbL]);
-               mesh.triangles.push([otbL, tbL, new_tbL], [otbL, new_tbL, new_otbL]);
-               mesh.triangles.push([tbR, otbR, new_otbR], [tbR, new_otbR, new_tbR]);
+               mesh.crosswalkTriangles.push([tbL, new_tbR, tbR], [tbL, new_tbL, new_tbR]);
+               mesh.sidewalkTriangles.push([otbL, new_tbL, tbL], [otbL, new_otbL, new_tbL]);
+               mesh.sidewalkTriangles.push([tbR, new_otbR, otbR], [tbR, new_tbR, new_otbR]);
+               mesh.triangles.push([tbL, new_tbR, tbR], [tbL, new_tbL, new_tbR]);
+               mesh.triangles.push([otbL, new_tbL, tbL], [otbL, new_otbL, new_tbL]);
+               mesh.triangles.push([tbR, new_otbR, otbR], [tbR, new_tbR, new_otbR]);
              }
 
              tbL = new_tbL; tbR = new_tbR;

--- a/tools/intersection-visualizer/src/lib/network.ts
+++ b/tools/intersection-visualizer/src/lib/network.ts
@@ -2,6 +2,7 @@ import { Point, Node, Edge } from "./types";
 import { sampleSpline } from "./splines";
 import { getEdgeClearance } from "./junctions";
 import { getDir } from "./math";
+import { DEFAULTS } from "./constants";
 
 export function findClosedAreas(nodes: Node[], edges: Edge[]): string[][] {
   const edgeSet = new Set(edges.filter(e => e.target).map(e => e.id));
@@ -235,7 +236,7 @@ export function getExtendedEdgeControlPoints(edge: Edge, nodes: Node[], edges: E
   const d0y = u1.y - p0.y;
   const len0 = Math.hypot(d0x, d0y);
 
-  let W0 = getEdgeClearance(edge.source, edge, true, nodes, edges, chamferAngleDeg) + (isTrueJunction(edge.source, nodes, edges) ? 14 : 0);
+  let W0 = getEdgeClearance(edge.source, edge, true, nodes, edges, chamferAngleDeg) + (isTrueJunction(edge.source, nodes, edges) ? DEFAULTS.crosswalkLength : 0);
 
   if (basePts.length === 2 && W0 > len0 / 2 - 5) {
       W0 = Math.max(0, len0 / 2 - 5);
@@ -260,7 +261,7 @@ export function getExtendedEdgeControlPoints(edge: Edge, nodes: Node[], edges: E
   const dnY = uLast.y - pN.y;
   const lenN = Math.hypot(dnX, dnY);
 
-  let WN = (edge.target ? getEdgeClearance(edge.target, edge, false, nodes, edges, chamferAngleDeg) : 0) + (edge.target && isTrueJunction(edge.target, nodes, edges) ? 14 : 0);
+  let WN = (edge.target ? getEdgeClearance(edge.target, edge, false, nodes, edges, chamferAngleDeg) : 0) + (edge.target && isTrueJunction(edge.target, nodes, edges) ? DEFAULTS.crosswalkLength : 0);
 
   if (basePts.length === 2 && WN > lenN / 2 - 5) {
       WN = Math.max(0, lenN / 2 - 5);


### PR DESCRIPTION
## Summary

- Preserve exported/manual polygon fills when importing or changing graph topology.
- Add a global operation to normalize short or backward junction handles past the crosswalk threshold.
- Fix exported mesh normals for junctions, target-end crosswalks, and smoothing triangles.
- Centralize the crosswalk length setting for mesh and network calculations.

## Validation

- `npm run lint`
- `npm run build`

The build completes with the existing Vite chunk-size warning.