### PR TITLE
[codex] Add extruded building polygons and linked fill

### DIFF
--- a/docs/ROAD_MAKER_SYNC.md
+++ b/docs/ROAD_MAKER_SYNC.md
@@ -70,6 +70,7 @@ Both meshers should produce the same conceptual groups:
 - `hubs`: junction records with `polygon`, `outerPolygon`, `corners`, and `outerCorners`.
 - `crosswalks`: crosswalk polygons used for display/debug and fill boundary behavior.
 - `polygonTriangles` / `polygonFills`: polygon-fill triangles and color metadata.
+- `buildingTriangles` / `buildingMeshes`: extruded authored building footprint geometry.
 - `centerLines`: sampled route/navigation centerlines.
 
 Names do not have to be identical when one side has compatibility aliases, but the
@@ -85,7 +86,8 @@ Keep this order aligned with Road-Maker:
 3. Build road strips, sidewalks, crosswalks, road polygons, outer road curves, and
    centerlines.
 4. Build polygon fills from road outer curves and hub outer polygons.
-5. Compute bounds.
+5. Build extruded building meshes from authored footprints.
+6. Compute bounds.
 
 Polygon fills depend on data generated earlier in the pipeline. If the fill mesh overlaps
 crosswalks or junction roads in Roblox but not in Road-Maker, first compare the boundary
@@ -164,6 +166,7 @@ For any mesher change:
    - sidewalk triangle count
    - crosswalk triangle count
    - polygon fill triangle count
+   - building triangle count
    - mesh bounds
 4. Check polygon fills with roads/crosswalks hidden in both tools to verify the raw fill
    geometry, not only layered rendering.

--- a/src/client/MinimapController.lua
+++ b/src/client/MinimapController.lua
@@ -80,6 +80,8 @@ local function getMinimapSurfaceStyle(part)
 		return MINIMAP_SIDEWALK_COLOR, Enum.Material.SmoothPlastic
 	elseif surfaceType == "crosswalk" then
 		return MINIMAP_CROSSWALK_COLOR, Enum.Material.SmoothPlastic
+	elseif surfaceType == "building" then
+		return Color3.fromRGB(76, 85, 99), Enum.Material.SmoothPlastic
 	end
 
 	return MINIMAP_ROAD_COLOR, Enum.Material.SmoothPlastic
@@ -197,7 +199,7 @@ end
 
 local function shouldUsePartForMinimapRoadMesh(part)
 	local surfaceType = part and part:GetAttribute("SurfaceType")
-	return surfaceType == "road" or surfaceType == "crosswalk"
+	return surfaceType == "road" or surfaceType == "crosswalk" or surfaceType == "building"
 end
 
 local function describeSource(source)

--- a/src/server/AuthoredRoadRuntime.lua
+++ b/src/server/AuthoredRoadRuntime.lua
@@ -1092,14 +1092,18 @@ end
 local function appendGraphBuildingCrashObstacles(target, graph)
 	for _, building in ipairs(graph.buildings or {}) do
 		local vertices = {}
+		local baseY = nil
 		for _, vertex in ipairs(building.vertices or {}) do
 			if typeof(vertex) == "Vector3" then
+				baseY = if baseY == nil then vertex.Y else math.min(baseY, vertex.Y)
 				table.insert(vertices, vertex)
 			end
 		end
 
 		if #vertices >= 3 then
-			local baseY = vertices[1].Y
+			for index, vertex in ipairs(vertices) do
+				vertices[index] = Vector3.new(vertex.X, baseY, vertex.Z)
+			end
 			local height = math.max(tonumber(building.height) or 80, 1)
 			table.insert(target, {
 				kind = "AuthoredBuildingPolygon",

--- a/src/server/AuthoredRoadRuntime.lua
+++ b/src/server/AuthoredRoadRuntime.lua
@@ -144,7 +144,7 @@ end
 
 local function shouldUsePartForMinimapRoadMesh(part)
 	local surfaceType = part and part:GetAttribute("SurfaceType")
-	return surfaceType == "road" or surfaceType == "crosswalk"
+	return surfaceType == "road" or surfaceType == "crosswalk" or surfaceType == "building"
 end
 
 local function normalizeRoadSource(value)
@@ -509,7 +509,19 @@ local function createRuntimeGraphMeshes(world, meshData)
 	for _, part in ipairs(result.collisionParts) do
 		part:SetAttribute("BakedRoadGraphMesh", true)
 		part:SetAttribute("BakeMode", "runtimeEditableMeshCollision")
-		part:SetAttribute("DriveSurface", true)
+		if part:GetAttribute("SurfaceType") == "building" then
+			part:SetAttribute("CrashObstacle", true)
+			part:SetAttribute("DriveSurface", nil)
+		else
+			part:SetAttribute("DriveSurface", true)
+		end
+	end
+
+	local crashObstacles = {}
+	for _, part in ipairs(result.collisionParts) do
+		if part:GetAttribute("CrashObstacle") == true then
+			table.insert(crashObstacles, part)
+		end
 	end
 
 	return {
@@ -518,6 +530,7 @@ local function createRuntimeGraphMeshes(world, meshData)
 		visibleParts = {},
 		collisionParts = result.collisionParts,
 		driveSurfaces = result.driveSurfaces,
+		crashObstacles = crashObstacles,
 		errors = result.errors,
 		source = "runtime-editable-collision",
 	}
@@ -684,12 +697,24 @@ local function useImportedBakedGraphMeshes(root, world, graph)
 		return nil, { "imported GLB bake had no collision MeshParts" }
 	end
 
+	local driveSurfaces = {}
+	local crashObstacles = {}
+	for _, part in ipairs(collisionParts) do
+		if part:GetAttribute("CrashObstacle") == true or part:GetAttribute("SurfaceType") == "building" then
+			part:SetAttribute("CrashObstacle", true)
+			table.insert(crashObstacles, part)
+		elseif part:GetAttribute("DriveSurface") == true or part:GetAttribute("SurfaceType") ~= "building" then
+			table.insert(driveSurfaces, part)
+		end
+	end
+
 	return {
 		meshFolder = meshFolder,
 		collisionFolder = collisionFolder,
 		visibleParts = visibleParts,
 		collisionParts = collisionParts,
-		driveSurfaces = collisionParts,
+		driveSurfaces = driveSurfaces,
+		crashObstacles = crashObstacles,
 		errors = errors,
 		source = source,
 	}, nil, meshData
@@ -1032,6 +1057,7 @@ local function createLegacyCurveWorld(root)
 	local driveSurfaces = {}
 	local crashObstacles = {}
 	appendAll(driveSurfaces, meshBuild.driveSurfaces)
+	appendAll(crashObstacles, meshBuild.crashObstacles)
 
 	local spawnPose = getLegacyCurveSpawnPose(root)
 	local cabCompanySpawnPose = buildAuthoredCabCompany(root, world, driveSurfaces, crashObstacles, "AuthoredCurveRoad")
@@ -1061,6 +1087,31 @@ local function createLegacyCurveWorld(root)
 
 	hideEditorRootForPlay(root, { preserveBakedGraph = false })
 	return world, driveSurfaces, crashObstacles, spawnPose
+end
+
+local function appendGraphBuildingCrashObstacles(target, graph)
+	for _, building in ipairs(graph.buildings or {}) do
+		local vertices = {}
+		for _, vertex in ipairs(building.vertices or {}) do
+			if typeof(vertex) == "Vector3" then
+				table.insert(vertices, vertex)
+			end
+		end
+
+		if #vertices >= 3 then
+			local baseY = vertices[1].Y
+			local height = math.max(tonumber(building.height) or 80, 1)
+			table.insert(target, {
+				kind = "AuthoredBuildingPolygon",
+				id = building.id,
+				name = building.name,
+				vertices = vertices,
+				baseY = baseY,
+				topY = baseY + height,
+				height = height,
+			})
+		end
+	end
 end
 
 local function createGraphWorld(root, graph)
@@ -1097,6 +1148,7 @@ local function createGraphWorld(root, graph)
 	local driveSurfaces = {}
 	local crashObstacles = {}
 	appendAll(driveSurfaces, meshBuild.driveSurfaces)
+	appendGraphBuildingCrashObstacles(crashObstacles, graph)
 
 	local spawnPose = getGraphSpawnPose(graph)
 	local authoredCabCompanyMarker = findAuthoredCabCompanyMarker(root)

--- a/src/server/Controllers/TaxiController.lua
+++ b/src/server/Controllers/TaxiController.lua
@@ -47,6 +47,77 @@ local function getOwnerAttributeName(config)
 	return "Cab87OwnerUserId"
 end
 
+local function pointInPolygonXZ(point, vertices)
+	local inside = false
+	for index = 1, #vertices do
+		local previousIndex = if index == 1 then #vertices else index - 1
+		local current = vertices[index]
+		local previous = vertices[previousIndex]
+		if
+			(current.Z > point.Z) ~= (previous.Z > point.Z)
+			and point.X < (previous.X - current.X) * (point.Z - current.Z) / (previous.Z - current.Z) + current.X
+		then
+			inside = not inside
+		end
+	end
+	return inside
+end
+
+local function closestPointOnSegmentXZ(point, a, b)
+	local abX = b.X - a.X
+	local abZ = b.Z - a.Z
+	local lengthSq = abX * abX + abZ * abZ
+	if lengthSq <= 0.0001 then
+		local dx = point.X - a.X
+		local dz = point.Z - a.Z
+		return a, math.sqrt(dx * dx + dz * dz)
+	end
+
+	local t = math.clamp(((point.X - a.X) * abX + (point.Z - a.Z) * abZ) / lengthSq, 0, 1)
+	local closest = Vector3.new(a.X + abX * t, point.Y, a.Z + abZ * t)
+	local dx = point.X - closest.X
+	local dz = point.Z - closest.Z
+	return closest, math.sqrt(dx * dx + dz * dz)
+end
+
+local function getPolygonCollisionPush(position, vertices, radius)
+	local point = Vector3.new(position.X, 0, position.Z)
+	local inside = pointInPolygonXZ(point, vertices)
+	local bestClosest = nil
+	local bestDistance = math.huge
+
+	for index = 1, #vertices do
+		local a = vertices[index]
+		local b = vertices[(index % #vertices) + 1]
+		local closest, distance = closestPointOnSegmentXZ(point, a, b)
+		if distance < bestDistance then
+			bestDistance = distance
+			bestClosest = closest
+		end
+	end
+
+	if not bestClosest then
+		return nil
+	end
+
+	local away = Vector3.new(position.X - bestClosest.X, 0, position.Z - bestClosest.Z)
+	if away.Magnitude <= 0.001 then
+		away = Vector3.new(1, 0, 0)
+	else
+		away = away.Unit
+	end
+
+	if inside then
+		return -away, radius + bestDistance
+	end
+
+	if bestDistance < radius then
+		return away, radius - bestDistance
+	end
+
+	return nil
+end
+
 local TaxiController = {}
 TaxiController.__index = TaxiController
 
@@ -739,51 +810,64 @@ function TaxiController:start()
 		local scrapeDirection = nil
 
 		for _, obstacle in ipairs(crashObstacles) do
-			local obstacleTop = obstacle.Position.Y + obstacle.Size.Y * 0.5
-			if resolved.Y < obstacleTop + Config.carCrashHeightClearance then
-				local halfX = obstacle.Size.X * 0.5 + Config.carCrashRadius
-				local halfZ = obstacle.Size.Z * 0.5 + Config.carCrashRadius
-				local deltaX = resolved.X - obstacle.Position.X
-				local deltaZ = resolved.Z - obstacle.Position.Z
-
-				if math.abs(deltaX) < halfX and math.abs(deltaZ) < halfZ then
-					local pushX = halfX - math.abs(deltaX)
-					local pushZ = halfZ - math.abs(deltaZ)
-					local normal
-
-					if pushX < pushZ then
-						local side = if deltaX >= 0 then 1 else -1
-						normal = Vector3.new(side, 0, 0)
-						resolved = Vector3.new(obstacle.Position.X + side * halfX, resolved.Y, resolved.Z)
-					else
-						local side = if deltaZ >= 0 then 1 else -1
-						normal = Vector3.new(0, 0, side)
-						resolved = Vector3.new(resolved.X, resolved.Y, obstacle.Position.Z + side * halfZ)
+			local normal = nil
+			if type(obstacle) == "table" and obstacle.kind == "AuthoredBuildingPolygon" then
+				local topY = tonumber(obstacle.topY) or math.huge
+				if resolved.Y < topY + Config.carCrashHeightClearance then
+					local pushNormal, penetration = getPolygonCollisionPush(resolved, obstacle.vertices or {}, Config.carCrashRadius)
+					if pushNormal and penetration and penetration > 0 then
+						normal = pushNormal
+						resolved += normal * penetration
 					end
+				end
+			elseif typeof(obstacle) == "Instance" and obstacle:IsA("BasePart") then
+				local obstacleTop = obstacle.Position.Y + obstacle.Size.Y * 0.5
+				if resolved.Y < obstacleTop + Config.carCrashHeightClearance then
+					local halfX = obstacle.Size.X * 0.5 + Config.carCrashRadius
+					local halfZ = obstacle.Size.Z * 0.5 + Config.carCrashRadius
+					local deltaX = resolved.X - obstacle.Position.X
+					local deltaZ = resolved.Z - obstacle.Position.Z
 
-					local intoWall = resolvedVelocity:Dot(normal)
-					local tangentVelocity = resolvedVelocity - normal * intoWall
-					local tangentSpeed = tangentVelocity.Magnitude
-					local speed = resolvedVelocity.Magnitude
-					local maxScrapeImpact = speed * math.sin(math.rad(Config.carWallScrapeMaxAngleDegrees))
+					if math.abs(deltaX) < halfX and math.abs(deltaZ) < halfZ then
+						local pushX = halfX - math.abs(deltaX)
+						local pushZ = halfZ - math.abs(deltaZ)
 
-					if intoWall < 0 then
-						local normalImpact = -intoWall
-						local canScrape = speed >= Config.carWallScrapeMinSpeed
-							and tangentSpeed > 0.001
-							and normalImpact <= maxScrapeImpact
-
-						if canScrape then
-							resolvedVelocity, scrapeDirection = getWallScrapeVelocity(tangentVelocity, normal, speed)
+						if pushX < pushZ then
+							local side = if deltaX >= 0 then 1 else -1
+							normal = Vector3.new(side, 0, 0)
+							resolved = Vector3.new(obstacle.Position.X + side * halfX, resolved.Y, resolved.Z)
 						else
-							hardCrashed = true
-							resolvedVelocity = tangentVelocity * Config.carCrashSlideRetain
-								+ normal * (normalImpact * Config.carCrashBounce)
+							local side = if deltaZ >= 0 then 1 else -1
+							normal = Vector3.new(0, 0, side)
+							resolved = Vector3.new(resolved.X, resolved.Y, obstacle.Position.Z + side * halfZ)
 						end
+					end
+				end
+			end
+
+			if normal then
+				local intoWall = resolvedVelocity:Dot(normal)
+				local tangentVelocity = resolvedVelocity - normal * intoWall
+				local tangentSpeed = tangentVelocity.Magnitude
+				local speed = resolvedVelocity.Magnitude
+				local maxScrapeImpact = speed * math.sin(math.rad(Config.carWallScrapeMaxAngleDegrees))
+
+				if intoWall < 0 then
+					local normalImpact = -intoWall
+					local canScrape = speed >= Config.carWallScrapeMinSpeed
+						and tangentSpeed > 0.001
+						and normalImpact <= maxScrapeImpact
+
+					if canScrape then
+						resolvedVelocity, scrapeDirection = getWallScrapeVelocity(tangentVelocity, normal, speed)
 					else
-						if tangentSpeed > Config.carWallScrapeMinSpeed then
-							_, scrapeDirection = getWallScrapeVelocity(tangentVelocity, normal, speed)
-						end
+						hardCrashed = true
+						resolvedVelocity = tangentVelocity * Config.carCrashSlideRetain
+							+ normal * (normalImpact * Config.carCrashBounce)
+					end
+				else
+					if tangentSpeed > Config.carWallScrapeMinSpeed then
+						_, scrapeDirection = getWallScrapeVelocity(tangentVelocity, normal, speed)
 					end
 				end
 			end

--- a/src/shared/RoadGraphData.lua
+++ b/src/shared/RoadGraphData.lua
@@ -34,6 +34,39 @@ local function finiteNumber(value)
 	return nil
 end
 
+local function lowestVectorY(vertices)
+	local lowest = nil
+	for _, vertex in ipairs(vertices or {}) do
+		if typeof(vertex) == "Vector3" then
+			lowest = if lowest == nil then vertex.Y else math.min(lowest, vertex.Y)
+		end
+	end
+	return lowest
+end
+
+local function lowestBaseZFromVectors(vertices, planeY, fallback)
+	local lowestY = lowestVectorY(vertices)
+	if lowestY ~= nil then
+		return lowestY - (finiteNumber(planeY) or 0)
+	end
+	return fallback
+end
+
+local function lowestBaseZFromPayload(building, fallback)
+	local lowest = nil
+	if type(building) == "table" and type(building.vertices) == "table" then
+		for _, vertex in ipairs(building.vertices) do
+			if type(vertex) == "table" then
+				local z = finiteNumber(vertex.elevation) or finiteNumber(vertex.z)
+				if z ~= nil then
+					lowest = if lowest == nil then z else math.min(lowest, z)
+				end
+			end
+		end
+	end
+	return lowest or fallback
+end
+
 local function sanitizeId(value, prefix, index)
 	if type(value) == "string" and value ~= "" then
 		return value
@@ -135,7 +168,10 @@ local function sanitizeBuildings(buildings, planeY)
 
 	for index, building in ipairs(buildings) do
 		if type(building) == "table" and type(building.vertices) == "table" then
-			local baseZ = finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION
+			local baseZ = lowestBaseZFromPayload(
+				building,
+				finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION
+			)
 			local vertices = {}
 			for _, vertex in ipairs(building.vertices) do
 				local point = graphPointToVector({
@@ -172,7 +208,7 @@ local function sanitizeBuildings(buildings, planeY)
 	return normalized
 end
 
-local function cloneBuildings(buildings)
+local function cloneBuildings(buildings, planeY)
 	local cloned = {}
 	for index, building in ipairs(buildings or {}) do
 		if type(building) == "table" and type(building.vertices) == "table" then
@@ -184,11 +220,21 @@ local function cloneBuildings(buildings)
 			end
 
 			if #vertices >= 3 then
+				local baseZ = lowestBaseZFromVectors(
+					vertices,
+					planeY,
+					finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION
+				)
+				local baseY = (finiteNumber(planeY) or 0) + baseZ
+				local flattenedVertices = {}
+				for _, vertex in ipairs(vertices) do
+					table.insert(flattenedVertices, Vector3.new(vertex.X, baseY, vertex.Z))
+				end
 				table.insert(cloned, {
 					id = sanitizeId(building.id, "b", index),
 					name = sanitizeName(building.name, nil),
-					vertices = vertices,
-					baseZ = finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION,
+					vertices = flattenedVertices,
+					baseZ = baseZ,
 					height = sanitizePositiveNumber(building.height, DEFAULT_BUILDING_HEIGHT),
 					color = sanitizeColor(building.color) or DEFAULT_BUILDING_COLOR,
 					material = sanitizeBuildingMaterial(building.material),
@@ -504,7 +550,11 @@ function RoadGraphData.scaleGraph(graph, options)
 			end
 
 			if #vertices >= 3 then
-				local baseZ = vertices[1].Y - planeY
+				local baseZ = lowestBaseZFromVectors(vertices, planeY, DEFAULT_BUILDING_BASE_ELEVATION)
+				local baseY = planeY + baseZ
+				for vertexIndex, vertex in ipairs(vertices) do
+					vertices[vertexIndex] = Vector3.new(vertex.X, baseY, vertex.Z)
+				end
 				table.insert(buildings, {
 					id = sanitizeId(building.id, "b", index),
 					name = sanitizeName(building.name, nil),
@@ -663,7 +713,8 @@ function RoadGraphData.writeGraph(root, graph, name)
 		end
 	end
 
-	local buildings = cloneBuildings(graph.buildings)
+	local planeY = finiteNumber(graph.planeY) or 0
+	local buildings = cloneBuildings(graph.buildings, planeY)
 	if #buildings > 0 then
 		local buildingsFolder = Instance.new("Folder")
 		buildingsFolder.Name = RoadGraphData.BUILDINGS_NAME
@@ -800,11 +851,21 @@ function RoadGraphData.collectGraph(root, config)
 			end
 
 			if #vertices >= 3 then
+				local planeY = finiteNumber(graphFolder:GetAttribute("PlaneY")) or 0
+				local baseZ = lowestBaseZFromVectors(
+					vertices,
+					planeY,
+					finiteNumber(buildingFolder:GetAttribute("BaseZ")) or DEFAULT_BUILDING_BASE_ELEVATION
+				)
+				local baseY = planeY + baseZ
+				for vertexIndex, vertex in ipairs(vertices) do
+					vertices[vertexIndex] = Vector3.new(vertex.X, baseY, vertex.Z)
+				end
 				table.insert(buildings, {
 					id = sanitizeId(buildingFolder:GetAttribute("BuildingId") or buildingFolder.Name, "b", index),
 					name = sanitizeName(buildingFolder:GetAttribute("DisplayName"), nil),
 					vertices = vertices,
-					baseZ = finiteNumber(buildingFolder:GetAttribute("BaseZ")) or (vertices[1].Y - (finiteNumber(graphFolder:GetAttribute("PlaneY")) or 0)),
+					baseZ = baseZ,
 					height = sanitizePositiveNumber(buildingFolder:GetAttribute("Height"), DEFAULT_BUILDING_HEIGHT),
 					color = sanitizeColor(buildingFolder:GetAttribute("Color")) or DEFAULT_BUILDING_COLOR,
 					material = sanitizeBuildingMaterial(buildingFolder:GetAttribute("Material")),
@@ -878,10 +939,11 @@ function RoadGraphData.toPayload(graph)
 			end
 
 			if #vertices >= 3 then
-				local baseZ = finiteNumber(building.baseZ)
-				if baseZ == nil and typeof(building.vertices[1]) == "Vector3" then
-					baseZ = building.vertices[1].Y - (finiteNumber(graph.planeY) or 0)
-				end
+				local baseZ = lowestBaseZFromVectors(
+					building.vertices,
+					graph.planeY,
+					finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION
+				)
 				table.insert(buildings, {
 					id = sanitizeId(building.id, "b", index),
 					name = building.name,

--- a/src/shared/RoadGraphData.lua
+++ b/src/shared/RoadGraphData.lua
@@ -5,7 +5,7 @@ local RoadSampling = require(script.Parent:WaitForChild("RoadSampling"))
 local RoadGraphData = {}
 
 RoadGraphData.SCHEMA = "cab87-road-network"
-RoadGraphData.VERSION = 1
+RoadGraphData.VERSION = 2
 RoadGraphData.EDITOR_ROOT_NAME = "Cab87RoadEditor"
 RoadGraphData.ROAD_GRAPH_NAME = "RoadGraph"
 RoadGraphData.RUNTIME_DATA_NAME = "AuthoredRoadGraphData"
@@ -14,11 +14,17 @@ RoadGraphData.EDGES_NAME = "Edges"
 RoadGraphData.EDGE_POINTS_NAME = "Points"
 RoadGraphData.POLYGON_FILLS_NAME = "PolygonFills"
 RoadGraphData.POLYGON_FILL_POINTS_NAME = "Points"
+RoadGraphData.BUILDINGS_NAME = "Buildings"
+RoadGraphData.BUILDING_VERTICES_NAME = "Vertices"
 
 local DEFAULT_CHAMFER_ANGLE_DEG = 70
 local DEFAULT_SIDEWALK_WIDTH = 12
 local DEFAULT_MESH_RESOLUTION = 20
 local DEFAULT_IMPORT_SCALE = 1
+local DEFAULT_BUILDING_BASE_ELEVATION = 4
+local DEFAULT_BUILDING_HEIGHT = 80
+local DEFAULT_BUILDING_COLOR = "#64748b"
+local DEFAULT_BUILDING_MATERIAL = "Concrete"
 
 local function finiteNumber(value)
 	local number = tonumber(value)
@@ -47,6 +53,14 @@ local function sanitizeColor(value)
 		return value
 	end
 	return nil
+end
+
+local function sanitizePositiveNumber(value, fallback)
+	local number = finiteNumber(value)
+	if number and number > 0 then
+		return number
+	end
+	return fallback
 end
 
 local function sanitizePolygonFills(fills, nodeLookup)
@@ -104,6 +118,87 @@ local function clonePolygonFills(fills, nodeLookup)
 	return cloned
 end
 
+local graphPointToVector
+
+local function sanitizeBuildingMaterial(value)
+	if type(value) == "string" and value ~= "" then
+		return value
+	end
+	return DEFAULT_BUILDING_MATERIAL
+end
+
+local function sanitizeBuildings(buildings, planeY)
+	local normalized = {}
+	if type(buildings) ~= "table" then
+		return normalized
+	end
+
+	for index, building in ipairs(buildings) do
+		if type(building) == "table" and type(building.vertices) == "table" then
+			local baseZ = finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION
+			local vertices = {}
+			for _, vertex in ipairs(building.vertices) do
+				local point = graphPointToVector({
+					x = vertex.x,
+					y = vertex.y,
+					z = baseZ,
+				}, planeY)
+				if point then
+					local previous = vertices[#vertices]
+					if not previous or (previous - point).Magnitude > 0.01 then
+						table.insert(vertices, point)
+					end
+				end
+			end
+
+			if #vertices > 2 and (vertices[1] - vertices[#vertices]).Magnitude <= 0.01 then
+				table.remove(vertices)
+			end
+
+			if #vertices >= 3 then
+				table.insert(normalized, {
+					id = sanitizeId(building.id, "b", index),
+					name = sanitizeName(building.name, nil),
+					vertices = vertices,
+					baseZ = baseZ,
+					height = sanitizePositiveNumber(building.height, DEFAULT_BUILDING_HEIGHT),
+					color = sanitizeColor(building.color) or DEFAULT_BUILDING_COLOR,
+					material = sanitizeBuildingMaterial(building.material),
+				})
+			end
+		end
+	end
+
+	return normalized
+end
+
+local function cloneBuildings(buildings)
+	local cloned = {}
+	for index, building in ipairs(buildings or {}) do
+		if type(building) == "table" and type(building.vertices) == "table" then
+			local vertices = {}
+			for _, vertex in ipairs(building.vertices) do
+				if typeof(vertex) == "Vector3" then
+					table.insert(vertices, vertex)
+				end
+			end
+
+			if #vertices >= 3 then
+				table.insert(cloned, {
+					id = sanitizeId(building.id, "b", index),
+					name = sanitizeName(building.name, nil),
+					vertices = vertices,
+					baseZ = finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION,
+					height = sanitizePositiveNumber(building.height, DEFAULT_BUILDING_HEIGHT),
+					color = sanitizeColor(building.color) or DEFAULT_BUILDING_COLOR,
+					material = sanitizeBuildingMaterial(building.material),
+				})
+			end
+		end
+	end
+	return cloned
+end
+
 local function sanitizeScale(value)
 	local number = finiteNumber(value) or DEFAULT_IMPORT_SCALE
 	return math.max(number, 0.001)
@@ -117,7 +212,7 @@ local function scaleNumber(value, scale)
 	return nil
 end
 
-local function graphPointToVector(point, planeY, pointScale)
+graphPointToVector = function(point, planeY, pointScale)
 	if type(point) ~= "table" then
 		return nil
 	end
@@ -321,6 +416,7 @@ function RoadGraphData.normalizePayload(payload, options)
 		nodes = normalizedNodes,
 		edges = normalizedEdges,
 		polygonFills = sanitizePolygonFills(payload.polygonFills, nodeLookup),
+		buildings = sanitizeBuildings(payload.buildings, planeY),
 	}
 
 	if pointScale ~= DEFAULT_IMPORT_SCALE or widthScale ~= DEFAULT_IMPORT_SCALE then
@@ -397,6 +493,31 @@ function RoadGraphData.scaleGraph(graph, options)
 		end
 	end
 
+	local buildings = {}
+	for index, building in ipairs(graph.buildings or {}) do
+		if type(building) == "table" then
+			local vertices = {}
+			for _, vertex in ipairs(building.vertices or {}) do
+				if typeof(vertex) == "Vector3" then
+					table.insert(vertices, scaleVectorFromPlane(vertex, planeY, pointScale))
+				end
+			end
+
+			if #vertices >= 3 then
+				local baseZ = vertices[1].Y - planeY
+				table.insert(buildings, {
+					id = sanitizeId(building.id, "b", index),
+					name = sanitizeName(building.name, nil),
+					vertices = vertices,
+					baseZ = baseZ,
+					height = sanitizePositiveNumber(building.height, DEFAULT_BUILDING_HEIGHT) * pointScale,
+					color = sanitizeColor(building.color) or DEFAULT_BUILDING_COLOR,
+					material = sanitizeBuildingMaterial(building.material),
+				})
+			end
+		end
+	end
+
 	return {
 		schema = graph.schema or RoadGraphData.SCHEMA,
 		version = tonumber(graph.version) or RoadGraphData.VERSION,
@@ -408,6 +529,7 @@ function RoadGraphData.scaleGraph(graph, options)
 		edges = edges,
 		nodeLookup = nodeLookup,
 		polygonFills = clonePolygonFills(graph.polygonFills, nodeLookup),
+		buildings = buildings,
 	}
 end
 
@@ -541,9 +663,42 @@ function RoadGraphData.writeGraph(root, graph, name)
 		end
 	end
 
+	local buildings = cloneBuildings(graph.buildings)
+	if #buildings > 0 then
+		local buildingsFolder = Instance.new("Folder")
+		buildingsFolder.Name = RoadGraphData.BUILDINGS_NAME
+		buildingsFolder.Parent = graphFolder
+
+		for index, building in ipairs(buildings) do
+			local buildingFolder = Instance.new("Folder")
+			buildingFolder.Name = sanitizeId(building.id, "b", index)
+			buildingFolder:SetAttribute("BuildingId", sanitizeId(building.id, "b", index))
+			if building.name then
+				buildingFolder:SetAttribute("DisplayName", building.name)
+			end
+			buildingFolder:SetAttribute("BaseZ", finiteNumber(building.baseZ) or DEFAULT_BUILDING_BASE_ELEVATION)
+			buildingFolder:SetAttribute("Height", sanitizePositiveNumber(building.height, DEFAULT_BUILDING_HEIGHT))
+			buildingFolder:SetAttribute("Color", sanitizeColor(building.color) or DEFAULT_BUILDING_COLOR)
+			buildingFolder:SetAttribute("Material", sanitizeBuildingMaterial(building.material))
+			buildingFolder.Parent = buildingsFolder
+
+			local verticesFolder = Instance.new("Folder")
+			verticesFolder.Name = RoadGraphData.BUILDING_VERTICES_NAME
+			verticesFolder.Parent = buildingFolder
+
+			for vertexIndex, vertex in ipairs(building.vertices or {}) do
+				local vertexValue = Instance.new("Vector3Value")
+				vertexValue.Name = string.format("V%04d", vertexIndex)
+				vertexValue.Value = vertex
+				vertexValue.Parent = verticesFolder
+			end
+		end
+	end
+
 	graphFolder:SetAttribute("NodeCount", #(graph.nodes or {}))
 	graphFolder:SetAttribute("EdgeCount", #(graph.edges or {}))
 	graphFolder:SetAttribute("PolygonFillCount", #polygonFills)
+	graphFolder:SetAttribute("BuildingCount", #buildings)
 	return graphFolder
 end
 
@@ -632,6 +787,32 @@ function RoadGraphData.collectGraph(root, config)
 		end
 	end
 
+	local buildings = {}
+	local buildingsFolder = childFolders(graphFolder, RoadGraphData.BUILDINGS_NAME)
+	for index, buildingFolder in ipairs(sortedChildren(buildingsFolder)) do
+		if buildingFolder:IsA("Folder") then
+			local vertices = {}
+			local verticesFolder = childFolders(buildingFolder, RoadGraphData.BUILDING_VERTICES_NAME)
+			for _, vertexValue in ipairs(sortedChildren(verticesFolder)) do
+				if vertexValue:IsA("Vector3Value") then
+					table.insert(vertices, vertexValue.Value)
+				end
+			end
+
+			if #vertices >= 3 then
+				table.insert(buildings, {
+					id = sanitizeId(buildingFolder:GetAttribute("BuildingId") or buildingFolder.Name, "b", index),
+					name = sanitizeName(buildingFolder:GetAttribute("DisplayName"), nil),
+					vertices = vertices,
+					baseZ = finiteNumber(buildingFolder:GetAttribute("BaseZ")) or (vertices[1].Y - (finiteNumber(graphFolder:GetAttribute("PlaneY")) or 0)),
+					height = sanitizePositiveNumber(buildingFolder:GetAttribute("Height"), DEFAULT_BUILDING_HEIGHT),
+					color = sanitizeColor(buildingFolder:GetAttribute("Color")) or DEFAULT_BUILDING_COLOR,
+					material = sanitizeBuildingMaterial(buildingFolder:GetAttribute("Material")),
+				})
+			end
+		end
+	end
+
 	if #nodes == 0 or #edges == 0 then
 		return nil
 	end
@@ -647,6 +828,7 @@ function RoadGraphData.collectGraph(root, config)
 		edges = edges,
 		nodeLookup = nodeLookup,
 		polygonFills = polygonFills,
+		buildings = buildings,
 	}
 end
 
@@ -682,6 +864,37 @@ function RoadGraphData.toPayload(graph)
 		})
 	end
 
+	local buildings = {}
+	for index, building in ipairs(graph.buildings or {}) do
+		if type(building) == "table" and type(building.vertices) == "table" then
+			local vertices = {}
+			for _, vertex in ipairs(building.vertices) do
+				if typeof(vertex) == "Vector3" then
+					table.insert(vertices, {
+						x = vertex.X,
+						y = vertex.Z,
+					})
+				end
+			end
+
+			if #vertices >= 3 then
+				local baseZ = finiteNumber(building.baseZ)
+				if baseZ == nil and typeof(building.vertices[1]) == "Vector3" then
+					baseZ = building.vertices[1].Y - (finiteNumber(graph.planeY) or 0)
+				end
+				table.insert(buildings, {
+					id = sanitizeId(building.id, "b", index),
+					name = building.name,
+					vertices = vertices,
+					baseZ = baseZ or DEFAULT_BUILDING_BASE_ELEVATION,
+					height = sanitizePositiveNumber(building.height, DEFAULT_BUILDING_HEIGHT),
+					color = sanitizeColor(building.color) or DEFAULT_BUILDING_COLOR,
+					material = sanitizeBuildingMaterial(building.material),
+				})
+			end
+		end
+	end
+
 	return {
 		schema = RoadGraphData.SCHEMA,
 		version = RoadGraphData.VERSION,
@@ -689,6 +902,7 @@ function RoadGraphData.toPayload(graph)
 		nodes = nodes,
 		edges = edges,
 		polygonFills = clonePolygonFills(graph.polygonFills),
+		buildings = buildings,
 	}
 end
 

--- a/src/shared/RoadGraphMesher.lua
+++ b/src/shared/RoadGraphMesher.lua
@@ -14,6 +14,16 @@ local function horizontalDistance(a, b)
 	return math.sqrt(dx * dx + dz * dz)
 end
 
+local function lowestY(points)
+	local lowest = nil
+	for _, point in ipairs(points or {}) do
+		if typeof(point) == "Vector3" then
+			lowest = if lowest == nil then point.Y else math.min(lowest, point.Y)
+		end
+	end
+	return lowest
+end
+
 local function getDir(fromPoint, toPoint)
 	local dx = toPoint.X - fromPoint.X
 	local dz = toPoint.Z - fromPoint.Z
@@ -688,6 +698,14 @@ local function buildBuildingMeshes(mesh, graph)
 			continue
 		end
 
+		local baseY = lowestY(baseVertices)
+		if baseY == nil then
+			continue
+		end
+		for vertexIndex, vertex in ipairs(baseVertices) do
+			baseVertices[vertexIndex] = Vector3.new(vertex.X, baseY, vertex.Z)
+		end
+
 		if horizontalDistance(baseVertices[1], baseVertices[#baseVertices]) <= 0.01 then
 			table.remove(baseVertices)
 		end
@@ -737,7 +755,7 @@ local function buildBuildingMeshes(mesh, graph)
 				id = building.id or ("b" .. tostring(index)),
 				name = building.name,
 				vertices = baseVertices,
-				baseZ = building.baseZ,
+				baseZ = baseY - (tonumber(graph.planeY) or 0),
 				height = height,
 				color = building.color or "#64748b",
 				material = building.material or "Concrete",

--- a/src/shared/RoadGraphMesher.lua
+++ b/src/shared/RoadGraphMesher.lua
@@ -667,6 +667,89 @@ local function buildPolygonFillTriangles(mesh, graph, edgeSplines)
 	end
 end
 
+local function buildBuildingMeshes(mesh, graph)
+	for index, building in ipairs(graph.buildings or {}) do
+		if type(building) ~= "table" or type(building.vertices) ~= "table" or #(building.vertices or {}) < 3 then
+			continue
+		end
+
+		local height = tonumber(building.height) or 80
+		if height <= EPSILON then
+			continue
+		end
+
+		local baseVertices = {}
+		for _, vertex in ipairs(building.vertices) do
+			if typeof(vertex) == "Vector3" then
+				table.insert(baseVertices, vertex)
+			end
+		end
+		if #baseVertices < 3 then
+			continue
+		end
+
+		if horizontalDistance(baseVertices[1], baseVertices[#baseVertices]) <= 0.01 then
+			table.remove(baseVertices)
+		end
+		if #baseVertices < 3 then
+			continue
+		end
+
+		local topVertices = {}
+		for _, vertex in ipairs(baseVertices) do
+			table.insert(topVertices, Vector3.new(vertex.X, vertex.Y + height, vertex.Z))
+		end
+
+		local topTriangles = buildGridMesh(topVertices)
+		local bottomSourceTriangles = buildGridMesh(baseVertices)
+		local bottomTriangles = {}
+		for _, triangle in ipairs(bottomSourceTriangles) do
+			addTriangle(bottomTriangles, triangle[1], triangle[3], triangle[2])
+		end
+
+		local wallTriangles = {}
+		for vertexIndex = 1, #baseVertices do
+			local nextIndex = (vertexIndex % #baseVertices) + 1
+			local baseA = baseVertices[vertexIndex]
+			local baseB = baseVertices[nextIndex]
+			local topB = topVertices[nextIndex]
+			local topA = topVertices[vertexIndex]
+			addTriangle(wallTriangles, baseA, baseB, topB)
+			addTriangle(wallTriangles, baseA, topB, topA)
+		end
+
+		local triangles = {}
+		for _, triangle in ipairs(topTriangles) do
+			table.insert(triangles, triangle)
+			table.insert(mesh.buildingTriangles, triangle)
+		end
+		for _, triangle in ipairs(bottomTriangles) do
+			table.insert(triangles, triangle)
+			table.insert(mesh.buildingTriangles, triangle)
+		end
+		for _, triangle in ipairs(wallTriangles) do
+			table.insert(triangles, triangle)
+			table.insert(mesh.buildingTriangles, triangle)
+		end
+
+		if #triangles > 0 then
+			table.insert(mesh.buildingMeshes, {
+				id = building.id or ("b" .. tostring(index)),
+				name = building.name,
+				vertices = baseVertices,
+				baseZ = building.baseZ,
+				height = height,
+				color = building.color or "#64748b",
+				material = building.material or "Concrete",
+				triangles = triangles,
+				topTriangles = topTriangles,
+				bottomTriangles = bottomTriangles,
+				wallTriangles = wallTriangles,
+			})
+		end
+	end
+end
+
 local function cubicBezier(p0, p1, p2, p3, t)
 	local t2 = t * t
 	local t3 = t2 * t
@@ -1278,6 +1361,8 @@ local function makeMeshData()
 		roadPolygons = {},
 		polygonFills = {},
 		polygonTriangles = {},
+		buildingMeshes = {},
+		buildingTriangles = {},
 		sidewalkPolygons = {},
 		crosswalks = {},
 		centerLines = {},
@@ -1701,10 +1786,12 @@ function RoadGraphMesher.buildNetworkMesh(graph, options)
 	end
 
 	buildPolygonFillTriangles(mesh, graph, edgeSplines)
+	buildBuildingMeshes(mesh, graph)
 
 	addTrianglesToBounds(mesh.bounds, mesh.roadTriangles)
 	addTrianglesToBounds(mesh.bounds, mesh.sidewalkTriangles)
 	addTrianglesToBounds(mesh.bounds, mesh.crosswalkTriangles)
+	addTrianglesToBounds(mesh.bounds, mesh.buildingTriangles)
 	for _, fill in ipairs(mesh.polygonFills) do
 		addTrianglesToBounds(mesh.bounds, fill.triangles)
 	end

--- a/src/shared/RoadMeshBuilder.lua
+++ b/src/shared/RoadMeshBuilder.lua
@@ -22,6 +22,12 @@ local DEFAULT_SURFACES = {
 		color = Color3.fromRGB(231, 226, 204),
 		material = Enum.Material.SmoothPlastic,
 	},
+	buildings = {
+		name = "BuildingSurface",
+		collisionName = "BuildingCollision",
+		color = Color3.fromRGB(100, 116, 139),
+		material = Enum.Material.Concrete,
+	},
 }
 
 local DEFAULT_CHUNK_SIZE = 1024
@@ -610,7 +616,7 @@ function RoadMeshBuilder.createCollisionMesh(parent, name, triangles, options)
 	collisionOptions.canTouch = false
 	collisionOptions.transparency = 1
 	collisionOptions.castShadow = false
-	collisionOptions.driveSurface = true
+	collisionOptions.driveSurface = if collisionOptions.driveSurface == false then false else true
 	collisionOptions.collisionFidelity = collisionOptions.collisionFidelity
 		or Enum.CollisionFidelity.PreciseConvexDecomposition
 	return createMeshPartFromState(state, parent, name, collisionOptions)
@@ -655,10 +661,14 @@ local function buildSurfacePair(meshParent, collisionParent, key, triangles, opt
 		generatedBy = options.generatedBy,
 		thickness = options.collisionThickness,
 		surfaceOffset = options.collisionSurfaceOffset,
+		driveSurface = key ~= "buildings",
 	})
 	if not collisionPart then
 		visiblePart:Destroy()
 		return nil, nil, collisionErr
+	end
+	if key == "buildings" then
+		collisionPart:SetAttribute("CrashObstacle", true)
 	end
 
 	return visiblePart, collisionPart, nil
@@ -879,9 +889,13 @@ local function buildChunkedCollision(collisionParent, key, triangles, options)
 					generatedBy = options.generatedBy,
 					thickness = options.collisionThickness,
 					surfaceOffset = options.collisionSurfaceOffset,
+					driveSurface = key ~= "buildings",
 				}
 			)
 			if collisionPart then
+				if key == "buildings" then
+					collisionPart:SetAttribute("CrashObstacle", true)
+				end
 				collisionPart:SetAttribute("MeshChunkKey", bucketKey)
 				collisionPart:SetAttribute("MeshChunkSize", chunkSize)
 				collisionPart:SetAttribute("MeshChunkY", bucket.chunkY)
@@ -1048,6 +1062,7 @@ function RoadMeshBuilder.createClassifiedMeshes(parent, meshData, options)
 		roads = meshData.roadTriangles,
 		sidewalks = meshData.sidewalkTriangles,
 		crosswalks = meshData.crosswalkTriangles,
+		buildings = meshData.buildingTriangles,
 	}
 
 	for key, triangles in pairs(surfaceSets) do
@@ -1055,7 +1070,11 @@ function RoadMeshBuilder.createClassifiedMeshes(parent, meshData, options)
 		if visiblePart and collisionPart then
 			table.insert(result.visibleParts, visiblePart)
 			table.insert(result.collisionParts, collisionPart)
-			table.insert(result.driveSurfaces, collisionPart)
+			if key == "buildings" then
+				collisionPart:SetAttribute("CrashObstacle", true)
+			else
+				table.insert(result.driveSurfaces, collisionPart)
+			end
 		elseif err then
 			table.insert(result.errors, string.format("%s: %s", key, tostring(err)))
 		end
@@ -1108,6 +1127,7 @@ function RoadMeshBuilder.createClassifiedCompactSurfaceMeshes(parent, meshData, 
 		{ key = "roads", triangles = meshData.roadTriangles, surfaceType = "road" },
 		{ key = "sidewalks", triangles = meshData.sidewalkTriangles },
 		{ key = "crosswalks", triangles = meshData.crosswalkTriangles },
+		{ key = "buildings", triangles = meshData.buildingTriangles },
 	}
 
 	for _, set in ipairs(surfaceSets) do
@@ -1187,8 +1207,9 @@ function RoadMeshBuilder.createClassifiedChunkedMeshes(parent, meshData, options
 		roads = meshData.roadTriangles,
 		sidewalks = meshData.sidewalkTriangles,
 		crosswalks = meshData.crosswalkTriangles,
+		buildings = meshData.buildingTriangles,
 	}
-	local surfaceKeys = options.surfaceKeys or { "roads", "sidewalks", "crosswalks" }
+	local surfaceKeys = options.surfaceKeys or { "roads", "sidewalks", "crosswalks", "buildings" }
 
 	for _, key in ipairs(surfaceKeys) do
 		local visibleParts, visibleErr = buildChunkedSurface(meshFolder, key, trianglesByKey[key], options)
@@ -1205,7 +1226,11 @@ function RoadMeshBuilder.createClassifiedChunkedMeshes(parent, meshData, options
 		end
 		for _, part in ipairs(collisionParts) do
 			table.insert(result.collisionParts, part)
-			table.insert(result.driveSurfaces, part)
+			if key == "buildings" then
+				part:SetAttribute("CrashObstacle", true)
+			else
+				table.insert(result.driveSurfaces, part)
+			end
 		end
 	end
 
@@ -1258,8 +1283,9 @@ function RoadMeshBuilder.createClassifiedChunkedSurfaceMeshes(parent, meshData, 
 		roads = meshData.roadTriangles,
 		sidewalks = meshData.sidewalkTriangles,
 		crosswalks = meshData.crosswalkTriangles,
+		buildings = meshData.buildingTriangles,
 	}
-	local surfaceKeys = options.surfaceKeys or { "roads", "sidewalks", "crosswalks" }
+	local surfaceKeys = options.surfaceKeys or { "roads", "sidewalks", "crosswalks", "buildings" }
 
 	for _, key in ipairs(surfaceKeys) do
 		local visibleParts, err = buildChunkedSurface(meshFolder, key, trianglesByKey[key], options)
@@ -1302,8 +1328,9 @@ function RoadMeshBuilder.createClassifiedChunkedCollisionMeshes(parent, meshData
 		roads = meshData.roadTriangles,
 		sidewalks = meshData.sidewalkTriangles,
 		crosswalks = meshData.crosswalkTriangles,
+		buildings = meshData.buildingTriangles,
 	}
-	local surfaceKeys = options.surfaceKeys or { "roads", "sidewalks", "crosswalks" }
+	local surfaceKeys = options.surfaceKeys or { "roads", "sidewalks", "crosswalks", "buildings" }
 
 	for _, key in ipairs(surfaceKeys) do
 		local collisionParts, err = buildChunkedCollision(collisionFolder, key, trianglesByKey[key], options)
@@ -1312,7 +1339,11 @@ function RoadMeshBuilder.createClassifiedChunkedCollisionMeshes(parent, meshData
 		end
 		for _, part in ipairs(collisionParts) do
 			table.insert(result.collisionParts, part)
-			table.insert(result.driveSurfaces, part)
+			if key == "buildings" then
+				part:SetAttribute("CrashObstacle", true)
+			else
+				table.insert(result.driveSurfaces, part)
+			end
 		end
 	end
 

--- a/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
+++ b/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
@@ -1366,14 +1366,17 @@ local function transformGraphToImportedCoordinates(root, RoadGraphData, transfor
 		end
 	end
 	for _, building in ipairs(graph.buildings or {}) do
+		local lowestY = nil
 		for index, vertex in ipairs(building.vertices or {}) do
 			if typeof(vertex) == "Vector3" then
-				building.vertices[index] = coordinateTransformPosition(vertex, transform)
+				local transformed = coordinateTransformPosition(vertex, transform)
+				building.vertices[index] = transformed
+				lowestY = if lowestY == nil then transformed.Y else math.min(lowestY, transformed.Y)
 				transformedPoints += 1
 			end
 		end
-		if typeof((building.vertices or {})[1]) == "Vector3" then
-			building.baseZ = building.vertices[1].Y - (tonumber(graph.planeY) or 0)
+		if lowestY ~= nil then
+			building.baseZ = lowestY - (tonumber(graph.planeY) or 0)
 		end
 	end
 

--- a/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
+++ b/studio-plugin/Cab87RoadGraphBuilder.plugin.lua
@@ -1105,6 +1105,10 @@ local function applyManifestPartOptions(part, chunk, mapIdValue, manifest)
 	if isCollision or chunk.driveSurface == true then
 		part:SetAttribute("DriveSurface", true)
 	end
+	if chunk.crashObstacle == true or tostring(chunk.surfaceType or "") == "building" then
+		part:SetAttribute("CrashObstacle", true)
+		part:SetAttribute("DriveSurface", nil)
+	end
 	if isCollision and collisionVerticalChunkSize and collisionVerticalChunkSize > 0 then
 		part:SetAttribute(COLLISION_VERTICAL_CHUNK_SIZE_ATTR, collisionVerticalChunkSize)
 	end
@@ -1361,6 +1365,17 @@ local function transformGraphToImportedCoordinates(root, RoadGraphData, transfor
 			end
 		end
 	end
+	for _, building in ipairs(graph.buildings or {}) do
+		for index, vertex in ipairs(building.vertices or {}) do
+			if typeof(vertex) == "Vector3" then
+				building.vertices[index] = coordinateTransformPosition(vertex, transform)
+				transformedPoints += 1
+			end
+		end
+		if typeof((building.vertices or {})[1]) == "Vector3" then
+			building.baseZ = building.vertices[1].Y - (tonumber(graph.planeY) or 0)
+		end
+	end
 
 	graphFolder = RoadGraphData.writeGraph(root, graph)
 	graphFolder:SetAttribute(GRAPH_COORDINATE_TRANSFORM_APPLIED_ATTR, true)
@@ -1534,7 +1549,7 @@ local function adoptImportedMeshFromManifest()
 			elseif surfaceType == "polygonFill" then
 				polygonFillTriangles += triangleCount
 			end
-			if surfaceType == "road" or surfaceType == "crosswalk" then
+			if surfaceType == "road" or surfaceType == "crosswalk" or surfaceType == "building" then
 				cloneMinimapPart(part, minimapFolder, mapId)
 				minimapParts += 1
 			end

--- a/tools/intersection-visualizer/README.md
+++ b/tools/intersection-visualizer/README.md
@@ -10,7 +10,9 @@ Run locally:
 ./run.sh
 ```
 
-Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for distance-based mesh density, then export JSON. The export format is `schema: "cab87-road-network"` / `version: 1` and is imported by the `Cab87 Road Graph Builder` Studio plugin. You can also export the current generated mesh as OBJ or GLB from the header; GLB keeps material colors, while OBJ is mostly geometry/object names. Use **Roblox** export for the large-map workflow: it downloads `cab87-road-mesh.zip`, containing a chunked GLB plus `cab87-road-mesh.manifest.json`, with visual and collision objects split by tile, elevation band, and triangle budget. The Roblox dropdown can also download the chunked GLB and manifest as individual files. In Studio, import the JSON, unzip and import the GLB with the 3D Importer, select the imported model, then click **Adopt Imported GLB Mesh** in the plugin and choose the manifest.
+Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for distance-based mesh density, then export JSON. The export format is `schema: "cab87-road-network"` / `version: 2` and is imported by the `Cab87 Road Graph Builder` Studio plugin. You can also export the current generated mesh as OBJ or GLB from the header; GLB keeps material colors, while OBJ is mostly geometry/object names. Use **Roblox** export for the large-map workflow: it downloads `cab87-road-mesh.zip`, containing a chunked GLB plus `cab87-road-mesh.manifest.json`, with visual and collision objects split by tile, elevation band, and triangle budget. The Roblox dropdown can also download the chunked GLB and manifest as individual files. In Studio, import the JSON, unzip and import the GLB with the 3D Importer, select the imported model, then click **Adopt Imported GLB Mesh** in the plugin and choose the manifest.
+
+Press **B** to toggle building mode. Left-click footprint vertices in the 2D view, then close the polygon by clicking the first vertex or pressing Enter. Building vertices can be dragged from the base in either view, the center handle moves the whole footprint in XY, and Shift-dragging the center/top handle in 3D adjusts height.
 
 Mesher changes must stay in parity with Roblox's Luau port in `src/shared/RoadGraphMesher.lua`.
 See [`../../docs/ROAD_MAKER_SYNC.md`](../../docs/ROAD_MAKER_SYNC.md) before changing
@@ -18,19 +20,31 @@ See [`../../docs/ROAD_MAKER_SYNC.md`](../../docs/ROAD_MAKER_SYNC.md) before chan
 
 ## Export Format
 
-Exports use the `cab87-road-network` JSON schema with `version: 1`. The payload includes
-`settings` for mesh-affecting editor options and the authored `nodes` and `edges` arrays:
+Exports use the `cab87-road-network` JSON schema with `version: 2`. The payload includes
+`settings` for mesh-affecting editor options and the authored `nodes`, `edges`, and
+`buildings` arrays:
 
 ```json
 {
   "schema": "cab87-road-network",
-  "version": 1,
+  "version": 2,
   "settings": {
     "chamferAngleDeg": 70,
     "meshResolution": 20
   },
   "nodes": [],
-  "edges": []
+  "edges": [],
+  "buildings": [
+    {
+      "id": "building-1",
+      "name": "Building 1",
+      "vertices": [{ "x": -80, "y": -60 }, { "x": -20, "y": -60 }, { "x": -20, "y": 20 }],
+      "baseZ": 4,
+      "height": 80,
+      "color": "#64748b",
+      "material": "Concrete"
+    }
+  ]
 }
 ```
 

--- a/tools/intersection-visualizer/README.md
+++ b/tools/intersection-visualizer/README.md
@@ -14,6 +14,8 @@ Open `http://localhost:3000`, author the graph, tune **Mesh Split Size** for dis
 
 Press **B** to toggle building mode. Left-click footprint vertices in the 2D view, then close the polygon by clicking the first vertex or pressing Enter. Building vertices can be dragged from the base in either view, the center handle moves the whole footprint in XY, and Shift-dragging the center/top handle in 3D adjusts height.
 
+Use **Building Fill** after selecting road edges or junctions to generate buildings from the current sidewalk edges. Open road selections place frontage buildings on both sides of the road. Closed block selections use the inner sidewalk boundary and generate four-point strip buildings along road curves and junction corners without collapsing footprints into the block center. Building fill keeps generated footprints linked to the selected roads, so adjusting a road curve regenerates the linked buildings from the updated sidewalk edge. Moving a generated building or dragging one of its vertices turns that footprint into a manual building. Tune min/max frontage width and vertical height in **Global > Settings**.
+
 Mesher changes must stay in parity with Roblox's Luau port in `src/shared/RoadGraphMesher.lua`.
 See [`../../docs/ROAD_MAKER_SYNC.md`](../../docs/ROAD_MAKER_SYNC.md) before changing
 `src/lib/meshing.ts`.
@@ -30,7 +32,13 @@ Exports use the `cab87-road-network` JSON schema with `version: 2`. The payload 
   "version": 2,
   "settings": {
     "chamferAngleDeg": 70,
-    "meshResolution": 20
+    "meshResolution": 20,
+    "buildingFill": {
+      "minWidth": 48,
+      "maxWidth": 120,
+      "minHeight": 50,
+      "maxHeight": 160
+    }
   },
   "nodes": [],
   "edges": [],

--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Point, Node, Edge, PointSelection, BuildingPolygon } from './lib/types';
+import { Point, Node, Edge, PointSelection, BuildingPolygon, BuildingFillSettings, BuildingFillSource, VisibilitySettings } from './lib/types';
 import { getExtendedEdgeControlPoints, sampleEdgeSpline, findClosedAreas } from './lib/network';
 import { getDir, distToSegment } from './lib/math';
 import { splitBezier } from './lib/splines';
@@ -11,15 +11,141 @@ import { buildNetworkMesh } from './lib/meshing';
 import { exportRoadMeshGlb, exportRoadMeshObj, exportRoadMeshRobloxPackage, type RobloxRoadMeshExportMode } from './lib/meshExport';
 import {
   COLORS, ROAD_NETWORK_SCHEMA, ROAD_NETWORK_VERSION,
-  sanitizeMeshResolution, DEFAULTS
+  sanitizeMeshResolution, sanitizeBuildingFillSettings, DEFAULTS
 } from './lib/constants';
 import { cleanBuildingVertices, getBuildingBaseZ, getBuildingCenter, getBuildingHeight, pointInBuilding } from './lib/buildings';
+import { generateBuildingFill } from './lib/buildingFill';
 
 type DragState = {
   type: 'node' | 'edge' | 'pan' | 'marquee' | 'building-center' | 'building-vertex';
   id: string;
   pointId?: number;
 };
+
+const DEFAULT_VISIBILITY_SETTINGS: VisibilitySettings = {
+  showNodeHandles: true,
+  showNodeControlPoints: true,
+  showPolyFillHandles: true,
+  showBuildingHandles: true,
+  showBuildingControlPoints: true,
+};
+
+function createBuildingFillGroupId() {
+  return `fill_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function parseImportedBuildingFillSource(value: any): BuildingFillSource | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const groupId = typeof value.groupId === 'string' && value.groupId ? value.groupId : '';
+  const mode = value.mode === 'closed' ? 'closed' : value.mode === 'open' ? 'open' : null;
+  const selectedNodes = Array.isArray(value.selectedNodes)
+    ? value.selectedNodes.filter((item: unknown): item is string => typeof item === 'string')
+    : [];
+  const selectedEdges = Array.isArray(value.selectedEdges)
+    ? value.selectedEdges.filter((item: unknown): item is string => typeof item === 'string')
+    : [];
+
+  if (!groupId || !mode || (selectedNodes.length === 0 && selectedEdges.length === 0)) return undefined;
+
+  return {
+    groupId,
+    mode,
+    selectedNodes,
+    selectedEdges,
+    settings: sanitizeBuildingFillSettings(value.settings),
+  };
+}
+
+function keepBuildingStyle(generated: BuildingPolygon, previous?: BuildingPolygon): BuildingPolygon {
+  if (!previous) return generated;
+  return {
+    ...generated,
+    name: previous.name ?? generated.name,
+    height: previous.height,
+    color: previous.color || generated.color,
+    material: previous.material ?? generated.material,
+  };
+}
+
+function regenerateLinkedBuildingGroups(params: {
+  buildings: BuildingPolygon[];
+  nodes: Node[];
+  edges: Edge[];
+  chamferAngle: number;
+  meshResolution: number;
+  laneWidth: number;
+}) {
+  const groups: { source: BuildingFillSource; buildings: BuildingPolygon[] }[] = [];
+  const groupById = new Map<string, { source: BuildingFillSource; buildings: BuildingPolygon[] }>();
+  const fixedBuildings: BuildingPolygon[] = [];
+
+  params.buildings.forEach((building) => {
+    const source = building.fillSource;
+    if (!source) {
+      fixedBuildings.push(building);
+      return;
+    }
+
+    let group = groupById.get(source.groupId);
+    if (!group) {
+      group = { source, buildings: [] };
+      groupById.set(source.groupId, group);
+      groups.push(group);
+    }
+    group.buildings.push(building);
+  });
+
+  if (groups.length === 0) return params.buildings;
+
+  const regeneratedByGroup = new Map<string, BuildingPolygon[]>();
+  const collisionBuildings = [...fixedBuildings];
+
+  groups.forEach((group) => {
+    const result = generateBuildingFill({
+      nodes: params.nodes,
+      edges: params.edges,
+      selectedNodes: group.source.selectedNodes,
+      selectedEdges: group.source.selectedEdges,
+      buildings: collisionBuildings,
+      chamferAngle: params.chamferAngle,
+      meshResolution: params.meshResolution,
+      laneWidth: params.laneWidth,
+      settings: group.source.settings,
+      seedSalt: group.source.groupId,
+    });
+
+    if (result.buildings.length === 0) return;
+
+    const previousById = new Map(group.buildings.map((building) => [building.id, building]));
+    const regenerated = result.buildings.map((building, index) => ({
+      ...keepBuildingStyle(building, previousById.get(building.id) ?? group.buildings[index]),
+      fillSource: group.source,
+    }));
+
+    regeneratedByGroup.set(group.source.groupId, regenerated);
+    collisionBuildings.push(...regenerated);
+  });
+
+  const emittedGroups = new Set<string>();
+  const nextBuildings: BuildingPolygon[] = [];
+
+  params.buildings.forEach((building) => {
+    const groupId = building.fillSource?.groupId;
+    if (!groupId) {
+      nextBuildings.push(building);
+      return;
+    }
+    if (emittedGroups.has(groupId)) return;
+    emittedGroups.add(groupId);
+
+    const regenerated = regeneratedByGroup.get(groupId);
+    if (regenerated) {
+      nextBuildings.push(...regenerated);
+    }
+  });
+
+  return nextBuildings;
+}
 
 export default function App() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -84,7 +210,7 @@ export default function App() {
 
   const [isMergeMode, setIsMergeMode] = useState(false);
   const [showMesh, setShowMesh] = useState(false);
-  const [showControlPoints, setShowControlPoints] = useState(true);
+  const [visibilitySettings, setVisibilitySettings] = useState<VisibilitySettings>(DEFAULT_VISIBILITY_SETTINGS);
   const [view, setView] = useState({ x: 0, y: 0, zoom: 1 });
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [selectedPoints, setSelectedPoints] = useState<PointSelection[]>([]);
@@ -92,6 +218,7 @@ export default function App() {
   const [chamferAngle, setChamferAngle] = useState(DEFAULTS.chamferAngle);
   const [meshResolution, setMeshResolution] = useState(DEFAULTS.meshResolution);
   const [laneWidth, setLaneWidth] = useState(DEFAULTS.laneWidth);
+  const [buildingFillSettings, setBuildingFillSettings] = useState<BuildingFillSettings>(() => sanitizeBuildingFillSettings());
   const [is3DMode, setIs3DMode] = useState(false);
   const [softSelectionEnabled, setSoftSelectionEnabled] = useState(false);
   const [softSelectionRadius, setSoftSelectionRadius] = useState(DEFAULTS.softSelectionRadius);
@@ -336,6 +463,7 @@ export default function App() {
         chamferAngleDeg: chamferAngle,
         meshResolution,
         laneWidth,
+        buildingFill: buildingFillSettings,
       },
       nodes,
       edges,
@@ -361,6 +489,64 @@ export default function App() {
     polygonFills,
     buildings
   );
+
+  useEffect(() => {
+    setBuildings(prev => regenerateLinkedBuildingGroups({
+      buildings: prev,
+      nodes,
+      edges,
+      chamferAngle,
+      meshResolution,
+      laneWidth,
+    }));
+  }, [nodes, edges, chamferAngle, meshResolution, laneWidth]);
+
+  const handleGenerateBuildingFill = () => {
+    const selectedPolygonFill = polygonFills.find((fill) => fill.id === selectedPolygonFillId) ?? null;
+    const fillSelectedNodes = selectedNodes.length > 0 || selectedEdges.length > 0
+      ? selectedNodes
+      : selectedPolygonFill?.points ?? selectedNodes;
+    const fillSelectedEdges = selectedNodes.length > 0 || selectedEdges.length > 0
+      ? selectedEdges
+      : [];
+    const groupId = createBuildingFillGroupId();
+    const result = generateBuildingFill({
+      nodes,
+      edges,
+      selectedNodes: fillSelectedNodes,
+      selectedEdges: fillSelectedEdges,
+      buildings,
+      chamferAngle,
+      meshResolution,
+      laneWidth,
+      settings: buildingFillSettings,
+      seedSalt: groupId,
+    });
+
+    if (result.buildings.length === 0) {
+      alert('Select a polygon fill, enclosed block, or road edges with enough sidewalk frontage for building fill.');
+      return;
+    }
+
+    const fillSource: BuildingFillSource = {
+      groupId,
+      mode: result.mode === 'closed' ? 'closed' : 'open',
+      selectedNodes: [...fillSelectedNodes],
+      selectedEdges: [...fillSelectedEdges],
+      settings: sanitizeBuildingFillSettings(buildingFillSettings),
+    };
+
+    setBuildings(prev => [
+      ...prev,
+      ...result.buildings.map((building) => ({
+        ...building,
+        fillSource,
+      })),
+    ]);
+    setBuildingDraft([]);
+    setIsBuildingMode(false);
+    clearBuildingSelection();
+  };
 
   const handleExportObj = () => {
     exportRoadMeshObj(buildCurrentMesh());
@@ -418,6 +604,12 @@ export default function App() {
           } else {
             setLaneWidth(DEFAULTS.laneWidth);
           }
+          setBuildingFillSettings(sanitizeBuildingFillSettings(data.settings?.buildingFill ?? {
+            minWidth: data.settings?.buildingFillMinWidth,
+            maxWidth: data.settings?.buildingFillMaxWidth,
+            minHeight: data.settings?.buildingFillMinHeight,
+            maxHeight: data.settings?.buildingFillMaxHeight,
+          }));
           if (Array.isArray(data.polygonFills)) {
             setPolygonFills(data.polygonFills);
           } else {
@@ -437,6 +629,7 @@ export default function App() {
               height: Math.max(1, typeof building.height === 'number' ? building.height : DEFAULTS.buildingHeight),
               color: typeof building.color === 'string' ? building.color : DEFAULTS.buildingColor,
               material: typeof building.material === 'string' ? building.material : DEFAULTS.buildingMaterial,
+              fillSource: parseImportedBuildingFillSource(building.fillSource),
             })).filter((building: BuildingPolygon) => building.vertices.length >= 3));
           } else {
             setBuildings([]);
@@ -525,6 +718,7 @@ export default function App() {
                     if (building.vertices.length <= 3) return [];
                     return [{
                         ...building,
+                        fillSource: undefined,
                         vertices: building.vertices.filter((_, index) => index !== selectedBuildingVertex.vertexIndex),
                     }];
                 }));
@@ -644,6 +838,37 @@ export default function App() {
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    if (!visibilitySettings.showBuildingControlPoints && selectedBuildingVertex) {
+      setSelectedBuildingVertex(null);
+      if (dragging?.type === 'building-vertex') {
+        setDragging(null);
+      }
+    }
+    if (!visibilitySettings.showBuildingHandles && dragging?.type === 'building-center') {
+      setDragging(null);
+    }
+    if (!visibilitySettings.showNodeControlPoints) {
+      if (selectedPoints.length > 0) {
+        setSelectedPoints([]);
+      }
+      if (dragging?.type === 'edge') {
+        setDragging(null);
+      }
+    }
+    if (!visibilitySettings.showNodeHandles) {
+      if (selectedNodes.length > 0) {
+        setSelectedNodes([]);
+      }
+      if (dragging?.type === 'node') {
+        setDragging(null);
+      }
+    }
+    if (!visibilitySettings.showPolyFillHandles && selectedPolygonFillId) {
+      setSelectedPolygonFillId(null);
+    }
+  }, [visibilitySettings, selectedBuildingVertex, selectedPoints.length, selectedNodes.length, selectedPolygonFillId, dragging]);
+
   // Automatic junction unlinking
   useEffect(() => {
     setNodes(prev => {
@@ -712,7 +937,7 @@ export default function App() {
     ctx.scale(view.zoom, view.zoom);
     drawNetwork2D(
       ctx, size, nodes, edges, selectedEdges, selectedNodes, selectedNode,
-      showMesh, showControlPoints, isAddNodeMode, isMergeMode,
+      showMesh, visibilitySettings, isAddNodeMode, isMergeMode,
       chamferAngle, meshResolution, laneWidth, polygonFills,
       buildings, selectedBuildingId, selectedBuildingVertex, buildingDraft,
       softSelectionEnabled, softSelectionRadius, draggingPoint, selectedPoints,
@@ -735,7 +960,7 @@ export default function App() {
       ctx.strokeRect(x, y, w, h);
       ctx.restore();
     }
-  }, [size, nodes, edges, selectedEdges, selectedNodes, selectedNode, selectedPoints, selectedPolygonFillId, selectedBuildingId, selectedBuildingVertex, isAddNodeMode, isMergeMode, showMesh, showControlPoints, view, chamferAngle, meshResolution, laneWidth, softSelectionEnabled, softSelectionRadius, draggingPoint, polygonFills, buildings, buildingDraft, marqueeStart, marqueeEnd, snapGridSize]);
+  }, [size, nodes, edges, selectedEdges, selectedNodes, selectedNode, selectedPoints, selectedPolygonFillId, selectedBuildingId, selectedBuildingVertex, isAddNodeMode, isMergeMode, showMesh, visibilitySettings, view, chamferAngle, meshResolution, laneWidth, softSelectionEnabled, softSelectionRadius, draggingPoint, polygonFills, buildings, buildingDraft, marqueeStart, marqueeEnd, snapGridSize]);
 
   const getMousePos = (e: React.PointerEvent | React.MouseEvent | any) => {
     let pos;
@@ -824,7 +1049,7 @@ export default function App() {
     };
 
     // Right click existing node
-    for (const n of nodes) {
+    for (const n of visibilitySettings.showNodeHandles ? nodes : []) {
         if (Math.hypot(pos.x - n.point.x, pos.y - n.point.y) < 25) {
             if (selectedNode && selectedNode !== n.id) {
                 const sn = nodes.find(nn => nn.id === selectedNode)!;
@@ -861,7 +1086,7 @@ export default function App() {
         const edge = edges[i];
         // Check control points
         for (let j = 0; j < edge.points.length; j++) {
-            if (!showControlPoints && j % 3 !== 2) continue;
+            if (!visibilitySettings.showNodeControlPoints) continue;
             if (Math.hypot(pos.x - edge.points[j].x, pos.y - edge.points[j].y) < 25) {
                 const newNodeId = Math.random().toString(36).substring(2, 9);
                 const newNode: Node = { id: newNodeId, point: edge.points[j] };
@@ -1082,22 +1307,24 @@ export default function App() {
       const height = getBuildingHeight(building);
       const center = getBuildingCenter(building);
 
-      for (let vertexIndex = building.vertices.length - 1; vertexIndex >= 0; vertexIndex--) {
-        const vertex = building.vertices[vertexIndex];
-        if (Math.hypot(pos.x - vertex.x, pos.y - vertex.y) < 18) {
-          setSelectedBuildingId(building.id);
-          setSelectedBuildingVertex({ buildingId: building.id, vertexIndex });
-          setSelectedNodes([]);
-          setSelectedEdges([]);
-          setSelectedPoints([]);
-          setSelectedPolygonFillId(null);
-          startDragPosRef.current = { x: vertex.x, y: vertex.y, z: baseZ };
-          setDragging({ type: 'building-vertex', id: building.id, pointId: vertexIndex });
-          return;
+      if (visibilitySettings.showBuildingControlPoints) {
+        for (let vertexIndex = building.vertices.length - 1; vertexIndex >= 0; vertexIndex--) {
+          const vertex = building.vertices[vertexIndex];
+          if (Math.hypot(pos.x - vertex.x, pos.y - vertex.y) < 18) {
+            setSelectedBuildingId(building.id);
+            setSelectedBuildingVertex({ buildingId: building.id, vertexIndex });
+            setSelectedNodes([]);
+            setSelectedEdges([]);
+            setSelectedPoints([]);
+            setSelectedPolygonFillId(null);
+            startDragPosRef.current = { x: vertex.x, y: vertex.y, z: baseZ };
+            setDragging({ type: 'building-vertex', id: building.id, pointId: vertexIndex });
+            return;
+          }
         }
       }
 
-      if (Math.hypot(pos.x - center.x, pos.y - center.y) < 22 || pointInBuilding(pos, building)) {
+      if (visibilitySettings.showBuildingHandles && (Math.hypot(pos.x - center.x, pos.y - center.y) < 22 || pointInBuilding(pos, building))) {
         setSelectedBuildingId(building.id);
         setSelectedBuildingVertex(null);
         setSelectedNodes([]);
@@ -1110,7 +1337,7 @@ export default function App() {
       }
     }
 
-    for (const pg of polygonFills) {
+    for (const pg of visibilitySettings.showPolyFillHandles ? polygonFills : []) {
       let cx = 0, cy = 0, count = 0;
       pg.points.forEach(nid => {
          const n = nodes.find(nn => nn.id === nid);
@@ -1129,7 +1356,7 @@ export default function App() {
     }
 
     // Click nodes
-    for (const n of nodes) {
+    for (const n of visibilitySettings.showNodeHandles ? nodes : []) {
         if (Math.hypot(pos.x - n.point.x, pos.y - n.point.y) < 25) {
             if (e.shiftKey) {
                 if (!selectedNodes.includes(n.id)) {
@@ -1361,7 +1588,7 @@ export default function App() {
     // Click edge points
     for (let i = edges.length - 1; i >= 0; i--) {
       for (let j = 0; j < edges[i].points.length; j++) {
-        if (!showControlPoints && j % 3 !== 2) continue;
+        if (!visibilitySettings.showNodeControlPoints) continue;
         if (Math.hypot(pos.x - edges[i].points[j].x, pos.y - edges[i].points[j].y) < 25) {
           if (e.altKey) {
             setEdges(prev => prev.map(edge => {
@@ -1721,6 +1948,7 @@ export default function App() {
         const dy = pos.y - center.y;
         return {
           ...building,
+          fillSource: undefined,
           vertices: building.vertices.map(vertex => ({
             ...vertex,
             x: vertex.x + dx,
@@ -1736,6 +1964,7 @@ export default function App() {
         if (building.id !== dragState.id) return building;
         return {
           ...building,
+          fillSource: undefined,
           vertices: building.vertices.map((vertex, index) => (
             index === dragState.pointId ? { ...vertex, x: pos.x, y: pos.y } : vertex
           )),
@@ -2118,7 +2347,7 @@ export default function App() {
         // If dropped near a node, attach it
         const pos = getMousePos(e);
         let targetNode = null;
-        for (const n of nodes) {
+        for (const n of visibilitySettings.showNodeHandles ? nodes : []) {
             if (Math.hypot(pos.x - n.point.x, pos.y - n.point.y) < (is3DMode ? 40 : 30)) {
                 targetNode = n.id;
                 break;
@@ -2183,8 +2412,6 @@ export default function App() {
         handleExportObj={handleExportObj}
         handleExportGlb={handleExportGlb}
         handleExportRoblox={handleExportRoblox}
-        showControlPoints={showControlPoints}
-        setShowControlPoints={setShowControlPoints}
         is3DMode={is3DMode}
         setIs3DMode={setIs3DMode}
         showMesh={showMesh}
@@ -2203,7 +2430,7 @@ export default function App() {
               meshResolution={meshResolution}
               laneWidth={laneWidth}
               showMesh={showMesh}
-              showControlPoints={showControlPoints}
+              visibilitySettings={visibilitySettings}
               setNodes={setNodes}
               setEdges={setEdges}
               view={view}
@@ -2305,6 +2532,11 @@ export default function App() {
           setMeshResolution={setMeshResolution}
           laneWidth={laneWidth}
           setLaneWidth={setLaneWidth}
+          buildingFillSettings={buildingFillSettings}
+          setBuildingFillSettings={setBuildingFillSettings}
+          visibilitySettings={visibilitySettings}
+          setVisibilitySettings={setVisibilitySettings}
+          onGenerateBuildingFill={handleGenerateBuildingFill}
           nodes={nodes}
           setNodes={setNodes}
           edges={edges}
@@ -2315,6 +2547,8 @@ export default function App() {
           setSelectedEdges={setSelectedEdges}
           buildings={buildings}
           setBuildings={setBuildings}
+          polygonFills={polygonFills}
+          selectedPolygonFillId={selectedPolygonFillId}
           selectedBuildingId={selectedBuildingId}
           selectedBuildingVertex={selectedBuildingVertex}
           setSelectedBuildingId={setSelectedBuildingId}

--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Point, Node, Edge, PointSelection } from './lib/types';
+import { Point, Node, Edge, PointSelection, BuildingPolygon } from './lib/types';
 import { getExtendedEdgeControlPoints, sampleEdgeSpline, findClosedAreas } from './lib/network';
 import { getDir, distToSegment } from './lib/math';
 import { splitBezier } from './lib/splines';
@@ -13,6 +13,13 @@ import {
   COLORS, ROAD_NETWORK_SCHEMA, ROAD_NETWORK_VERSION,
   sanitizeMeshResolution, DEFAULTS
 } from './lib/constants';
+import { cleanBuildingVertices, getBuildingBaseZ, getBuildingCenter, getBuildingHeight, pointInBuilding } from './lib/buildings';
+
+type DragState = {
+  type: 'node' | 'edge' | 'pan' | 'marquee' | 'building-center' | 'building-vertex';
+  id: string;
+  pointId?: number;
+};
 
 export default function App() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -37,6 +44,11 @@ export default function App() {
   const startDragPosRef = useRef<Point | null>(null);
   const addedToSelectionRef = useRef<boolean>(false);
   const [selectedNodes, setSelectedNodes] = useState<string[]>([]);
+  const [buildings, setBuildings] = useState<BuildingPolygon[]>([]);
+  const [selectedBuildingId, setSelectedBuildingId] = useState<string | null>(null);
+  const [selectedBuildingVertex, setSelectedBuildingVertex] = useState<{ buildingId: string; vertexIndex: number } | null>(null);
+  const [isBuildingMode, setIsBuildingMode] = useState(false);
+  const [buildingDraft, setBuildingDraft] = useState<Point[]>([]);
   const selectedNode = selectedNodes.length > 0 ? selectedNodes[selectedNodes.length - 1] : null;
 
   const setSelectedNode = (id: string | null) => {
@@ -44,7 +56,7 @@ export default function App() {
   };
   const [isAddNodeMode, setIsAddNodeMode] = useState(false);
 
-  const [dragging, setDragging] = useState<{ type: 'node' | 'edge' | 'pan' | 'marquee'; id: string; pointId?: number } | null>(null);
+  const [dragging, setDragging] = useState<DragState | null>(null);
   const [marqueeStart, setMarqueeStart] = useState<Point | null>(null);
   const [marqueeEnd, setMarqueeEnd] = useState<Point | null>(null);
 
@@ -56,8 +68,19 @@ export default function App() {
         if (dragging.pointId != null) return edge ? edge.points[dragging.pointId] : null;
         else if (lastDragPosRef.current) return lastDragPosRef.current;
     }
+    if (dragging.type === 'building-center') {
+      const building = buildings.find((item) => item.id === dragging.id);
+      if (!building) return null;
+      const center = getBuildingCenter(building);
+      return { ...center, z: getBuildingBaseZ(building) + getBuildingHeight(building) };
+    }
+    if (dragging.type === 'building-vertex') {
+      const building = buildings.find((item) => item.id === dragging.id);
+      const vertex = building && dragging.pointId != null ? building.vertices[dragging.pointId] : null;
+      return vertex ? { ...vertex, z: getBuildingBaseZ(building!) } : null;
+    }
     return null;
-  }, [dragging, nodes, edges]);
+  }, [dragging, nodes, edges, buildings]);
 
   const [isMergeMode, setIsMergeMode] = useState(false);
   const [showMesh, setShowMesh] = useState(false);
@@ -83,6 +106,7 @@ export default function App() {
     crossroads: true,
     lines: true,
     polyFills: true,
+    buildings: true,
   });
 
   const handleMatchSelectedZToLast = () => {
@@ -147,6 +171,39 @@ export default function App() {
 
   const [polygonFills, setPolygonFills] = useState<{ id: string; points: string[]; color: string }[]>([]);
   const [deletedFaces, setDeletedFaces] = useState<string[]>([]);
+
+  const clearBuildingSelection = () => {
+    setSelectedBuildingId(null);
+    setSelectedBuildingVertex(null);
+  };
+
+  const clearRoadSelection = () => {
+    setSelectedNode(null);
+    setSelectedEdges([]);
+    setSelectedPoints([]);
+    setSelectedPolygonFillId(null);
+  };
+
+  const finishBuildingDraft = (vertices = buildingDraft) => {
+    const cleanedVertices = cleanBuildingVertices(vertices);
+    if (cleanedVertices.length < 3) return false;
+
+    const id = Math.random().toString(36).substring(2, 9);
+    const nextBuilding: BuildingPolygon = {
+      id,
+      vertices: cleanedVertices,
+      baseZ: DEFAULTS.buildingBaseZ,
+      height: DEFAULTS.buildingHeight,
+      color: DEFAULTS.buildingColor,
+      material: DEFAULTS.buildingMaterial,
+    };
+    setBuildings(prev => [...prev, nextBuilding]);
+    setSelectedBuildingId(id);
+    setSelectedBuildingVertex(null);
+    clearRoadSelection();
+    setBuildingDraft([]);
+    return true;
+  };
 
   const getFaceKey = (points: string[]) => {
     let minKey = points.join(',');
@@ -283,6 +340,7 @@ export default function App() {
       nodes,
       edges,
       polygonFills,
+      buildings,
       deletedFaces,
     }, null, 2);
     const blob = new Blob([data], { type: 'application/json' });
@@ -300,7 +358,8 @@ export default function App() {
     chamferAngle,
     meshResolution,
     laneWidth,
-    polygonFills
+    polygonFills,
+    buildings
   );
 
   const handleExportObj = () => {
@@ -369,10 +428,27 @@ export default function App() {
           } else {
             setDeletedFaces([]);
           }
+          if (Array.isArray(data.buildings)) {
+            setBuildings(data.buildings.map((building: any, index: number) => ({
+              id: typeof building.id === 'string' && building.id ? building.id : `b${index + 1}`,
+              name: typeof building.name === 'string' ? building.name : undefined,
+              vertices: cleanBuildingVertices(Array.isArray(building.vertices) ? building.vertices : []),
+              baseZ: typeof building.baseZ === 'number' ? building.baseZ : DEFAULTS.buildingBaseZ,
+              height: Math.max(1, typeof building.height === 'number' ? building.height : DEFAULTS.buildingHeight),
+              color: typeof building.color === 'string' ? building.color : DEFAULTS.buildingColor,
+              material: typeof building.material === 'string' ? building.material : DEFAULTS.buildingMaterial,
+            })).filter((building: BuildingPolygon) => building.vertices.length >= 3));
+          } else {
+            setBuildings([]);
+          }
           setSelectedEdges([]);
           setSelectedNode(null);
           setSelectedPoints([]);
+          setSelectedBuildingId(null);
+          setSelectedBuildingVertex(null);
+          setBuildingDraft([]);
           setIsAddNodeMode(false);
+          setIsBuildingMode(false);
           setDragging(null);
           setIsMergeMode(false);
         } else {
@@ -398,17 +474,38 @@ export default function App() {
         setSelectedNode(null);
         setSelectedEdges([]);
         setSelectedPoints([]);
+        clearBuildingSelection();
         setDragging(null);
         setIsAddNodeMode(false);
+        setIsBuildingMode(false);
+        setBuildingDraft([]);
         setIsMergeMode(false);
+      }
+      if (isBuildingMode && e.key === 'Enter') {
+        finishBuildingDraft();
+        return;
+      }
+      if (isBuildingMode && (e.key === 'Backspace' || e.key === 'Delete') && buildingDraft.length > 0) {
+        setBuildingDraft(prev => prev.slice(0, -1));
+        return;
       }
       if (e.key.toLowerCase() === 'c') {
         setIsAddNodeMode(prev => !prev);
         setIsMergeMode(false);
+        setIsBuildingMode(false);
+        setBuildingDraft([]);
       }
       if (e.key.toLowerCase() === 'm') {
         setIsMergeMode(prev => !prev);
         setIsAddNodeMode(false);
+        setIsBuildingMode(false);
+        setBuildingDraft([]);
+      }
+      if (e.key.toLowerCase() === 'b') {
+        setIsBuildingMode(prev => !prev);
+        setIsAddNodeMode(false);
+        setIsMergeMode(false);
+        setBuildingDraft([]);
       }
       if (e.key.toLowerCase() === 'p' && !e.ctrlKey) {
         if (selectedNodes.length >= 3) {
@@ -421,6 +518,22 @@ export default function App() {
         }
       }
       if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (selectedBuildingId) {
+            if (selectedBuildingVertex) {
+                setBuildings(prev => prev.flatMap(building => {
+                    if (building.id !== selectedBuildingVertex.buildingId) return [building];
+                    if (building.vertices.length <= 3) return [];
+                    return [{
+                        ...building,
+                        vertices: building.vertices.filter((_, index) => index !== selectedBuildingVertex.vertexIndex),
+                    }];
+                }));
+            } else {
+                setBuildings(prev => prev.filter(building => building.id !== selectedBuildingId));
+            }
+            clearBuildingSelection();
+            return;
+        }
         if (selectedPolygonFillId) {
             setPolygonFills(prev => {
                 const pf = prev.find(p => p.id === selectedPolygonFillId);
@@ -487,6 +600,14 @@ export default function App() {
               maxY = Math.max(maxY, p.y);
             });
           });
+          buildings.forEach(building => {
+            building.vertices.forEach(vertex => {
+              minX = Math.min(minX, vertex.x);
+              minY = Math.min(minY, vertex.y);
+              maxX = Math.max(maxX, vertex.x);
+              maxY = Math.max(maxY, vertex.y);
+            });
+          });
 
           if (minX !== Infinity) {
             const padding = 100;
@@ -510,7 +631,7 @@ export default function App() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [selectedNode, selectedEdges, selectedPoints, nodes, edges, size, isMergeMode, isAddNodeMode]);
+  }, [selectedNode, selectedEdges, selectedPoints, selectedBuildingId, selectedBuildingVertex, buildingDraft, nodes, edges, buildings, size, isMergeMode, isAddNodeMode, isBuildingMode]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -593,6 +714,7 @@ export default function App() {
       ctx, size, nodes, edges, selectedEdges, selectedNodes, selectedNode,
       showMesh, showControlPoints, isAddNodeMode, isMergeMode,
       chamferAngle, meshResolution, laneWidth, polygonFills,
+      buildings, selectedBuildingId, selectedBuildingVertex, buildingDraft,
       softSelectionEnabled, softSelectionRadius, draggingPoint, selectedPoints,
       selectedPolygonFillId, view, snapGridSize
     );
@@ -613,7 +735,7 @@ export default function App() {
       ctx.strokeRect(x, y, w, h);
       ctx.restore();
     }
-  }, [size, nodes, edges, selectedEdges, selectedNodes, selectedNode, selectedPoints, selectedPolygonFillId, isAddNodeMode, isMergeMode, showMesh, showControlPoints, view, chamferAngle, meshResolution, laneWidth, softSelectionEnabled, softSelectionRadius, draggingPoint, polygonFills, marqueeStart, marqueeEnd, snapGridSize]);
+  }, [size, nodes, edges, selectedEdges, selectedNodes, selectedNode, selectedPoints, selectedPolygonFillId, selectedBuildingId, selectedBuildingVertex, isAddNodeMode, isMergeMode, showMesh, showControlPoints, view, chamferAngle, meshResolution, laneWidth, softSelectionEnabled, softSelectionRadius, draggingPoint, polygonFills, buildings, buildingDraft, marqueeStart, marqueeEnd, snapGridSize]);
 
   const getMousePos = (e: React.PointerEvent | React.MouseEvent | any) => {
     let pos;
@@ -925,6 +1047,26 @@ export default function App() {
 
     const pos = getMousePos(e);
 
+    if (e.button === 0 && isBuildingMode) {
+      if (buildingDraft.length >= 3 && Math.hypot(pos.x - buildingDraft[0].x, pos.y - buildingDraft[0].y) < 18) {
+        finishBuildingDraft();
+        return;
+      }
+
+      const nextDraft = [...buildingDraft, { x: pos.x, y: pos.y }];
+      if (e.detail >= 2 && nextDraft.length >= 3) {
+        finishBuildingDraft(nextDraft);
+        return;
+      }
+      setBuildingDraft(nextDraft);
+      setSelectedEdges([]);
+      setSelectedNode(null);
+      setSelectedPoints([]);
+      clearBuildingSelection();
+      setSelectedPolygonFillId(null);
+      return;
+    }
+
     // Divert behavior to handleRightClick if in Add Node Mode
     if (e.button === 0 && isAddNodeMode) {
       handleRightClick(e, pos);
@@ -932,6 +1074,42 @@ export default function App() {
     }
 
     setSelectedPolygonFillId(null);
+    clearBuildingSelection();
+
+    for (let i = buildings.length - 1; i >= 0; i--) {
+      const building = buildings[i];
+      const baseZ = getBuildingBaseZ(building);
+      const height = getBuildingHeight(building);
+      const center = getBuildingCenter(building);
+
+      for (let vertexIndex = building.vertices.length - 1; vertexIndex >= 0; vertexIndex--) {
+        const vertex = building.vertices[vertexIndex];
+        if (Math.hypot(pos.x - vertex.x, pos.y - vertex.y) < 18) {
+          setSelectedBuildingId(building.id);
+          setSelectedBuildingVertex({ buildingId: building.id, vertexIndex });
+          setSelectedNodes([]);
+          setSelectedEdges([]);
+          setSelectedPoints([]);
+          setSelectedPolygonFillId(null);
+          startDragPosRef.current = { x: vertex.x, y: vertex.y, z: baseZ };
+          setDragging({ type: 'building-vertex', id: building.id, pointId: vertexIndex });
+          return;
+        }
+      }
+
+      if (Math.hypot(pos.x - center.x, pos.y - center.y) < 22 || pointInBuilding(pos, building)) {
+        setSelectedBuildingId(building.id);
+        setSelectedBuildingVertex(null);
+        setSelectedNodes([]);
+        setSelectedEdges([]);
+        setSelectedPoints([]);
+        setSelectedPolygonFillId(null);
+        startDragPosRef.current = { x: center.x, y: center.y, z: baseZ + height };
+        setDragging({ type: 'building-center', id: building.id });
+        return;
+      }
+    }
+
     for (const pg of polygonFills) {
       let cx = 0, cy = 0, count = 0;
       pg.points.forEach(nid => {
@@ -1525,7 +1703,47 @@ export default function App() {
       return changed ? { ...edge, points: newPts } : edge;
   };
 
-  const handleDrag = (dragState: { type: 'node' | 'edge' | 'pan' | 'marquee'; id: string; pointId?: number }, pos: Point, shiftKey: boolean) => {
+  const handleDrag = (dragState: DragState, pos: Point, shiftKey: boolean) => {
+    if (dragState.type === 'building-center') {
+      setBuildings(prev => prev.map(building => {
+        if (building.id !== dragState.id) return building;
+        const center = getBuildingCenter(building);
+        const baseZ = getBuildingBaseZ(building);
+
+        if (is3DMode && shiftKey && pos.z !== undefined) {
+          return {
+            ...building,
+            height: Math.max(1, pos.z - baseZ),
+          };
+        }
+
+        const dx = pos.x - center.x;
+        const dy = pos.y - center.y;
+        return {
+          ...building,
+          vertices: building.vertices.map(vertex => ({
+            ...vertex,
+            x: vertex.x + dx,
+            y: vertex.y + dy,
+          })),
+        };
+      }));
+      return;
+    }
+
+    if (dragState.type === 'building-vertex' && dragState.pointId !== undefined) {
+      setBuildings(prev => prev.map(building => {
+        if (building.id !== dragState.id) return building;
+        return {
+          ...building,
+          vertices: building.vertices.map((vertex, index) => (
+            index === dragState.pointId ? { ...vertex, x: pos.x, y: pos.y } : vertex
+          )),
+        };
+      }));
+      return;
+    }
+
     const taper = (dist: number, radius: number) => Math.max(0, 1 - Math.pow(dist / radius, 2));
     const pointEpsilon = 0.0001;
     const numbersEqual = (a: number | undefined, b: number | undefined, fallback?: number) => {
@@ -1980,6 +2198,7 @@ export default function App() {
               nodes={nodes}
               edges={edges}
               polygonFills={polygonFills}
+              buildings={buildings}
               chamferAngle={chamferAngle}
               meshResolution={meshResolution}
               laneWidth={laneWidth}
@@ -2004,6 +2223,8 @@ export default function App() {
               selectedEdges={selectedEdges}
               selectedPoints={selectedPoints}
               selectedPolygonFillId={selectedPolygonFillId}
+              selectedBuildingId={selectedBuildingId}
+              selectedBuildingVertex={selectedBuildingVertex}
               marqueeStart={marqueeStart}
               marqueeEnd={marqueeEnd}
               snapGridSize={snapGridSize}
@@ -2048,6 +2269,7 @@ export default function App() {
                 <div className="text-white font-bold flex flex-col gap-1.5 opacity-90"><span className="text-blue-300">Scroll</span> Zoom</div>
                 <div className="text-white font-bold flex flex-col gap-1.5 opacity-90"><span className="text-blue-300">Click Edge</span> Add Point</div>
                 <div className="text-white font-bold flex flex-col gap-1.5 opacity-90"><span className="text-blue-300">P</span> (with 3+ nodes) Fill Polygon</div>
+                <div className="text-white font-bold flex flex-col gap-1.5 opacity-90"><span className={isBuildingMode ? "text-orange-400" : "text-blue-300"}>B</span>{isBuildingMode ? "Click Footprint" : "Building Mode"}</div>
                 <div className="text-white font-bold flex flex-col gap-1.5 opacity-90"><span className="text-blue-300">Esc</span> Deselect</div>
               </div>
             </>
@@ -2059,6 +2281,15 @@ export default function App() {
           setIsSidebarOpen={setIsSidebarOpen}
           isAddNodeMode={isAddNodeMode}
           setIsAddNodeMode={setIsAddNodeMode}
+          isBuildingMode={isBuildingMode}
+          setIsBuildingMode={(value) => {
+            setIsBuildingMode(value);
+            if (value) {
+              setIsAddNodeMode(false);
+              setIsMergeMode(false);
+            }
+            setBuildingDraft([]);
+          }}
           softSelectionEnabled={softSelectionEnabled}
           setSoftSelectionEnabled={setSoftSelectionEnabled}
           softSelectionRadius={softSelectionRadius}
@@ -2082,6 +2313,12 @@ export default function App() {
           setSelectedNodes={setSelectedNodes}
           selectedEdges={selectedEdges}
           setSelectedEdges={setSelectedEdges}
+          buildings={buildings}
+          setBuildings={setBuildings}
+          selectedBuildingId={selectedBuildingId}
+          selectedBuildingVertex={selectedBuildingVertex}
+          setSelectedBuildingId={setSelectedBuildingId}
+          setSelectedBuildingVertex={setSelectedBuildingVertex}
           debugOptions={debugOptions}
           setDebugOptions={setDebugOptions}
         />

--- a/tools/intersection-visualizer/src/App.tsx
+++ b/tools/intersection-visualizer/src/App.tsx
@@ -13,7 +13,7 @@ import {
   COLORS, ROAD_NETWORK_SCHEMA, ROAD_NETWORK_VERSION,
   sanitizeMeshResolution, sanitizeBuildingFillSettings, DEFAULTS
 } from './lib/constants';
-import { cleanBuildingVertices, getBuildingBaseZ, getBuildingCenter, getBuildingHeight, pointInBuilding } from './lib/buildings';
+import { cleanBuildingVertices, getBuildingBaseZ, getBuildingCenter, getBuildingHeight, getLowestPointZ, pointInBuilding } from './lib/buildings';
 import { generateBuildingFill } from './lib/buildingFill';
 
 type DragState = {
@@ -319,7 +319,7 @@ export default function App() {
     const nextBuilding: BuildingPolygon = {
       id,
       vertices: cleanedVertices,
-      baseZ: DEFAULTS.buildingBaseZ,
+      baseZ: getLowestPointZ(cleanedVertices, DEFAULTS.buildingBaseZ),
       height: DEFAULTS.buildingHeight,
       color: DEFAULTS.buildingColor,
       material: DEFAULTS.buildingMaterial,
@@ -1278,7 +1278,11 @@ export default function App() {
         return;
       }
 
-      const nextDraft = [...buildingDraft, { x: pos.x, y: pos.y }];
+      const draftPoint: Point = { x: pos.x, y: pos.y };
+      if (typeof pos.z === 'number' && Number.isFinite(pos.z)) {
+        draftPoint.z = pos.z;
+      }
+      const nextDraft = [...buildingDraft, draftPoint];
       if (e.detail >= 2 && nextDraft.length >= 3) {
         finishBuildingDraft(nextDraft);
         return;

--- a/tools/intersection-visualizer/src/ThreeScene.tsx
+++ b/tools/intersection-visualizer/src/ThreeScene.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { Node, Edge, Point, PointSelection, BuildingPolygon } from './lib/types';
+import { Node, Edge, Point, PointSelection, BuildingPolygon, VisibilitySettings } from './lib/types';
 import { buildNetworkMesh } from './lib/meshing';
 import { SceneContent } from './components/three/SceneContent';
 
@@ -13,7 +13,7 @@ interface ThreeSceneProps {
   meshResolution: number;
   laneWidth?: number;
   showMesh: boolean;
-  showControlPoints: boolean;
+  visibilitySettings: VisibilitySettings;
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   setEdges: React.Dispatch<React.SetStateAction<Edge[]>>;
   onPointerDown: (e: any) => void;
@@ -42,7 +42,7 @@ interface ThreeSceneProps {
 }
 
 export default function ThreeScene({
-    nodes, edges, polygonFills, buildings, chamferAngle, meshResolution, laneWidth, showMesh, showControlPoints,
+    nodes, edges, polygonFills, buildings, chamferAngle, meshResolution, laneWidth, showMesh, visibilitySettings,
     setNodes, setEdges,
     onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onContextMenu,
     isDragging, draggingPoint, selectedNode, selectedNodes, selectedEdges, selectedPoints, selectedPolygonFillId, selectedBuildingId, selectedBuildingVertex,
@@ -78,7 +78,7 @@ export default function ThreeScene({
           polygonFills={polygonFills}
           buildings={buildings}
           showMesh={showMesh}
-          showControlPoints={showControlPoints}
+          visibilitySettings={visibilitySettings}
           nodes={nodes}
           edges={edges}
           chamferAngle={chamferAngle}

--- a/tools/intersection-visualizer/src/ThreeScene.tsx
+++ b/tools/intersection-visualizer/src/ThreeScene.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { MeshData, Node, Edge, Point, PointSelection } from './lib/types';
+import { Node, Edge, Point, PointSelection, BuildingPolygon } from './lib/types';
 import { buildNetworkMesh } from './lib/meshing';
 import { SceneContent } from './components/three/SceneContent';
 
@@ -8,6 +8,7 @@ interface ThreeSceneProps {
   nodes: Node[];
   edges: Edge[];
   polygonFills: any[];
+  buildings: BuildingPolygon[];
   chamferAngle: number;
   meshResolution: number;
   laneWidth?: number;
@@ -26,6 +27,8 @@ interface ThreeSceneProps {
   selectedEdges: string[];
   selectedPoints: PointSelection[];
   selectedPolygonFillId: string | null;
+  selectedBuildingId: string | null;
+  selectedBuildingVertex: { buildingId: string; vertexIndex: number } | null;
   view: { x: number, y: number, zoom: number };
   setView: React.Dispatch<React.SetStateAction<{ x: number, y: number, zoom: number }>>;
   containerRef: React.RefObject<HTMLDivElement>;
@@ -39,14 +42,14 @@ interface ThreeSceneProps {
 }
 
 export default function ThreeScene({
-    nodes, edges, polygonFills, chamferAngle, meshResolution, laneWidth, showMesh, showControlPoints,
+    nodes, edges, polygonFills, buildings, chamferAngle, meshResolution, laneWidth, showMesh, showControlPoints,
     setNodes, setEdges,
     onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onContextMenu,
-    isDragging, draggingPoint, selectedNode, selectedNodes, selectedEdges, selectedPoints, selectedPolygonFillId,
+    isDragging, draggingPoint, selectedNode, selectedNodes, selectedEdges, selectedPoints, selectedPolygonFillId, selectedBuildingId, selectedBuildingVertex,
     softSelectionEnabled, softSelectionRadius,
     view, setView, containerRef, marqueeStart, marqueeEnd, snapGridSize, debugOptions
 }: ThreeSceneProps) {
-  const mesh = useMemo(() => buildNetworkMesh(nodes, edges, chamferAngle, meshResolution, laneWidth || 30, polygonFills), [nodes, edges, chamferAngle, meshResolution, laneWidth, polygonFills]);
+  const mesh = useMemo(() => buildNetworkMesh(nodes, edges, chamferAngle, meshResolution, laneWidth || 30, polygonFills, buildings), [nodes, edges, chamferAngle, meshResolution, laneWidth, polygonFills, buildings]);
 
   const initialCameraParams = useMemo(() => {
     const cW = containerRef.current?.clientWidth || 800;
@@ -73,6 +76,7 @@ export default function ThreeScene({
         <SceneContent
           mesh={mesh}
           polygonFills={polygonFills}
+          buildings={buildings}
           showMesh={showMesh}
           showControlPoints={showControlPoints}
           nodes={nodes}
@@ -90,6 +94,8 @@ export default function ThreeScene({
           selectedEdges={selectedEdges}
           selectedPoints={selectedPoints}
           selectedPolygonFillId={selectedPolygonFillId}
+          selectedBuildingId={selectedBuildingId}
+          selectedBuildingVertex={selectedBuildingVertex}
           initialCameraParams={initialCameraParams}
           softSelectionEnabled={softSelectionEnabled}
           softSelectionRadius={softSelectionRadius}

--- a/tools/intersection-visualizer/src/components/Header.tsx
+++ b/tools/intersection-visualizer/src/components/Header.tsx
@@ -10,8 +10,6 @@ interface HeaderProps {
   handleExportObj: () => void;
   handleExportGlb: () => void;
   handleExportRoblox: (mode?: RobloxRoadMeshExportMode) => void;
-  showControlPoints: boolean;
-  setShowControlPoints: (v: boolean) => void;
   is3DMode: boolean;
   setIs3DMode: (v: boolean) => void;
   showMesh: boolean;
@@ -26,8 +24,6 @@ export default function Header({
   handleExportObj,
   handleExportGlb,
   handleExportRoblox,
-  showControlPoints,
-  setShowControlPoints,
   is3DMode,
   setIs3DMode,
   showMesh,
@@ -165,16 +161,6 @@ export default function Header({
           )}
         </div>
         <div className="w-px h-6 bg-slate-700 hidden sm:block mx-1"></div>
-        <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-300 font-medium hover:text-white sm:mr-2">
-          <input
-            type="checkbox"
-            className="rounded bg-slate-800 border-slate-700 text-blue-600 focus:ring-blue-500 focus:ring-offset-slate-900 w-4 h-4 cursor-pointer"
-            checked={showControlPoints}
-            onChange={(e) => setShowControlPoints(e.target.checked)}
-          />
-          <span className="hidden md:inline">Show Control Points</span>
-          <span className="md:hidden">Points</span>
-        </label>
         <button
           onClick={() => setIs3DMode(!is3DMode)}
           className={`p-2 lg:px-3 lg:py-1.5 border rounded text-sm font-semibold flex items-center gap-2 transition-colors ${

--- a/tools/intersection-visualizer/src/components/Sidebar.tsx
+++ b/tools/intersection-visualizer/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { X, ChevronDown, ChevronRight, Copy, ClipboardPaste, Trash2 } from 'lucide-react';
 import { Node, Edge, BuildingPolygon, BuildingFillSettings, VisibilitySettings, PolygonFill } from '../lib/types';
 import { sanitizeBuildingFillSettings, sanitizeMeshResolution } from '../lib/constants';
+import { getBuildingBaseZ } from '../lib/buildings';
 import { getEdgeClearance } from '../lib/junctions';
 import { isTrueJunction } from '../lib/network';
 
@@ -505,10 +506,15 @@ export default function Sidebar({
                           <label className="text-xs text-slate-400 block mb-1">Base Z</label>
                           <input
                             type="number"
-                            value={Math.round(selectedBuilding.baseZ ?? DEFAULTS.buildingBaseZ)}
+                            value={Math.round(getBuildingBaseZ(selectedBuilding))}
                             onChange={(evt) => {
                               const value = parseFloat(evt.target.value);
-                              setBuildings(prev => prev.map(building => building.id === selectedBuilding.id ? { ...building, baseZ: Number.isFinite(value) ? value : DEFAULTS.buildingBaseZ } : building));
+                              const nextBaseZ = Number.isFinite(value) ? value : DEFAULTS.buildingBaseZ;
+                              setBuildings(prev => prev.map(building => building.id === selectedBuilding.id ? {
+                                ...building,
+                                baseZ: nextBaseZ,
+                                vertices: building.vertices.map(vertex => ({ ...vertex, z: nextBaseZ })),
+                              } : building));
                             }}
                             className="w-full bg-slate-800 text-white border border-slate-600 rounded p-1 text-xs focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 transition-colors"
                           />

--- a/tools/intersection-visualizer/src/components/Sidebar.tsx
+++ b/tools/intersection-visualizer/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { X, ChevronDown, ChevronRight, Copy, ClipboardPaste, Trash2 } from 'lucide-react';
-import { Node, Edge } from '../lib/types';
+import { Node, Edge, BuildingPolygon } from '../lib/types';
 import { sanitizeMeshResolution } from '../lib/constants';
 import { getEdgeClearance } from '../lib/junctions';
 import { isTrueJunction } from '../lib/network';
@@ -14,6 +14,8 @@ interface SidebarProps {
   setIsSidebarOpen: (v: boolean) => void;
   isAddNodeMode: boolean;
   setIsAddNodeMode: (v: boolean) => void;
+  isBuildingMode: boolean;
+  setIsBuildingMode: (v: boolean) => void;
   softSelectionEnabled: boolean;
   setSoftSelectionEnabled: (v: boolean) => void;
   softSelectionRadius: number;
@@ -37,6 +39,12 @@ interface SidebarProps {
   setSelectedNodes: React.Dispatch<React.SetStateAction<string[]>>;
   selectedEdges: string[];
   setSelectedEdges: React.Dispatch<React.SetStateAction<string[]>>;
+  buildings: BuildingPolygon[];
+  setBuildings: React.Dispatch<React.SetStateAction<BuildingPolygon[]>>;
+  selectedBuildingId: string | null;
+  selectedBuildingVertex: { buildingId: string; vertexIndex: number } | null;
+  setSelectedBuildingId: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedBuildingVertex: React.Dispatch<React.SetStateAction<{ buildingId: string; vertexIndex: number } | null>>;
   debugOptions: any;
   setDebugOptions: (v: any) => void;
 }
@@ -46,6 +54,8 @@ export default function Sidebar({
   setIsSidebarOpen,
   isAddNodeMode,
   setIsAddNodeMode,
+  isBuildingMode,
+  setIsBuildingMode,
   softSelectionEnabled,
   setSoftSelectionEnabled,
   softSelectionRadius,
@@ -69,6 +79,12 @@ export default function Sidebar({
   setSelectedNodes,
   selectedEdges,
   setSelectedEdges,
+  buildings,
+  setBuildings,
+  selectedBuildingId,
+  selectedBuildingVertex,
+  setSelectedBuildingId,
+  setSelectedBuildingVertex,
   debugOptions,
   setDebugOptions,
 }: SidebarProps) {
@@ -83,6 +99,7 @@ export default function Sidebar({
   const [globalScaleMap, setGlobalScaleMap] = useState<string>("1.5");
   const [globalScaleRoads, setGlobalScaleRoads] = useState<string>("1.5");
   const [globalScaleSidewalks, setGlobalScaleSidewalks] = useState<string>("1.5");
+  const selectedBuilding = buildings.find((building) => building.id === selectedBuildingId) || null;
 
   const applyGlobalScaleMap = () => {
     const scale = parseFloat(globalScaleMap);
@@ -98,6 +115,12 @@ export default function Sidebar({
         maxX = Math.max(maxX, p.x); maxY = Math.max(maxY, p.y);
       });
     });
+    buildings.forEach(building => {
+      building.vertices.forEach(vertex => {
+        minX = Math.min(minX, vertex.x); minY = Math.min(minY, vertex.y);
+        maxX = Math.max(maxX, vertex.x); maxY = Math.max(maxY, vertex.y);
+      });
+    });
 
     if (minX !== Infinity) {
       const cx = (minX + maxX) / 2;
@@ -111,6 +134,11 @@ export default function Sidebar({
       setEdges(prev => prev.map(e => ({
         ...e,
         points: e.points.map(p => ({ ...p, x: cx + (p.x - cx) * scale, y: cy + (p.y - cy) * scale }))
+      })));
+
+      setBuildings(prev => prev.map(building => ({
+        ...building,
+        vertices: building.vertices.map(vertex => ({ ...vertex, x: cx + (vertex.x - cx) * scale, y: cy + (vertex.y - cy) * scale })),
       })));
     }
     setGlobalScaleMap("1.0");
@@ -285,6 +313,18 @@ export default function Sidebar({
                     {isAddNodeMode ? 'Add Node Mode: ON' : 'Add Node'}
                   </button>
               </div>
+              <div className="flex gap-2 mt-2">
+                  <button
+                      onClick={() => setIsBuildingMode(!isBuildingMode)}
+                      className={`flex-1 px-3 py-1.5 rounded text-sm font-semibold flex justify-center items-center gap-2 transition-colors ${
+                        isBuildingMode
+                          ? 'bg-orange-600 hover:bg-orange-500 text-white border border-orange-400'
+                          : 'bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700'
+                      }`}
+                  >
+                    {isBuildingMode ? 'Building Mode: ON' : 'Add Building'}
+                  </button>
+              </div>
             </section>
 
 
@@ -385,12 +425,79 @@ export default function Sidebar({
           </div>
           {!collapsedSections['selected_items'] && (
             <div className="space-y-3 overflow-y-auto pb-4">
-              {selectedNodes.length === 0 && selectedEdges.length === 0 ? (
+              {selectedNodes.length === 0 && selectedEdges.length === 0 && !selectedBuilding ? (
                 <div className="text-sm text-slate-500 text-center py-4 px-4 bg-slate-800/10 rounded-lg border border-slate-800/50 border-dashed">
-                  Select a junction or road in the viewport.
+                  Select a junction, road, or building in the viewport.
                 </div>
               ) : (
                 <>
+                  {selectedBuilding && (
+                    <div className="p-3 bg-orange-900/10 rounded-xl border border-orange-500/50 flex flex-col gap-3">
+                      <div className="flex justify-between items-center text-sm font-bold text-slate-200">
+                        <span>{selectedBuilding.name || `Building ${selectedBuilding.id.substring(0, 4)}`}</span>
+                        <button
+                          onClick={(evt) => {
+                            evt.stopPropagation();
+                            setBuildings(prev => prev.filter(building => building.id !== selectedBuilding.id));
+                            setSelectedBuildingId(null);
+                            setSelectedBuildingVertex(null);
+                          }}
+                          className="text-slate-500 hover:text-red-400 p-1 rounded-lg hover:bg-slate-800 transition-colors"
+                        >
+                          <Trash2 className="w-4 h-4 opacity-70" />
+                        </button>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div>
+                          <label className="text-xs text-slate-400 block mb-1">Base Z</label>
+                          <input
+                            type="number"
+                            value={Math.round(selectedBuilding.baseZ ?? DEFAULTS.buildingBaseZ)}
+                            onChange={(evt) => {
+                              const value = parseFloat(evt.target.value);
+                              setBuildings(prev => prev.map(building => building.id === selectedBuilding.id ? { ...building, baseZ: Number.isFinite(value) ? value : DEFAULTS.buildingBaseZ } : building));
+                            }}
+                            className="w-full bg-slate-800 text-white border border-slate-600 rounded p-1 text-xs focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 transition-colors"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-400 block mb-1">Height</label>
+                          <input
+                            type="number"
+                            min="1"
+                            value={Math.round(selectedBuilding.height)}
+                            onChange={(evt) => {
+                              const value = parseFloat(evt.target.value);
+                              setBuildings(prev => prev.map(building => building.id === selectedBuilding.id ? { ...building, height: Math.max(1, Number.isFinite(value) ? value : DEFAULTS.buildingHeight) } : building));
+                            }}
+                            className="w-full bg-slate-800 text-white border border-slate-600 rounded p-1 text-xs focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 transition-colors"
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <label className="text-xs text-slate-400 block mb-1">Color</label>
+                        <div className="flex gap-2">
+                          <input
+                            type="color"
+                            value={selectedBuilding.color || DEFAULTS.buildingColor}
+                            onChange={(evt) => setBuildings(prev => prev.map(building => building.id === selectedBuilding.id ? { ...building, color: evt.target.value } : building))}
+                            className="h-8 w-12 bg-slate-800 border border-slate-700 rounded cursor-pointer"
+                          />
+                          <input
+                            type="text"
+                            value={selectedBuilding.color || DEFAULTS.buildingColor}
+                            onChange={(evt) => setBuildings(prev => prev.map(building => building.id === selectedBuilding.id ? { ...building, color: evt.target.value } : building))}
+                            className="flex-1 min-w-0 bg-slate-800 text-white border border-slate-600 rounded p-1 text-xs focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 transition-colors"
+                          />
+                        </div>
+                      </div>
+                      {selectedBuildingVertex && (
+                        <div className="text-xs text-orange-200 bg-orange-950/40 border border-orange-900 rounded p-2">
+                          Vertex {selectedBuildingVertex.vertexIndex + 1} selected
+                        </div>
+                      )}
+                    </div>
+                  )}
                   {nodes.filter(n => selectedNodes.includes(n.id)).map((n) => (
                     <div
                       key={n.id}

--- a/tools/intersection-visualizer/src/components/Sidebar.tsx
+++ b/tools/intersection-visualizer/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { X, ChevronDown, ChevronRight, Copy, ClipboardPaste, Trash2 } from 'lucide-react';
-import { Node, Edge, BuildingPolygon } from '../lib/types';
-import { sanitizeMeshResolution } from '../lib/constants';
+import { Node, Edge, BuildingPolygon, BuildingFillSettings, VisibilitySettings, PolygonFill } from '../lib/types';
+import { sanitizeBuildingFillSettings, sanitizeMeshResolution } from '../lib/constants';
 import { getEdgeClearance } from '../lib/junctions';
 import { isTrueJunction } from '../lib/network';
 
@@ -31,6 +31,11 @@ interface SidebarProps {
   setMeshResolution: (v: number) => void;
   laneWidth: number;
   setLaneWidth: (v: number) => void;
+  buildingFillSettings: BuildingFillSettings;
+  setBuildingFillSettings: React.Dispatch<React.SetStateAction<BuildingFillSettings>>;
+  visibilitySettings: VisibilitySettings;
+  setVisibilitySettings: React.Dispatch<React.SetStateAction<VisibilitySettings>>;
+  onGenerateBuildingFill: () => void;
   nodes: Node[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   edges: Edge[];
@@ -41,6 +46,8 @@ interface SidebarProps {
   setSelectedEdges: React.Dispatch<React.SetStateAction<string[]>>;
   buildings: BuildingPolygon[];
   setBuildings: React.Dispatch<React.SetStateAction<BuildingPolygon[]>>;
+  polygonFills: PolygonFill[];
+  selectedPolygonFillId: string | null;
   selectedBuildingId: string | null;
   selectedBuildingVertex: { buildingId: string; vertexIndex: number } | null;
   setSelectedBuildingId: React.Dispatch<React.SetStateAction<string | null>>;
@@ -71,6 +78,11 @@ export default function Sidebar({
   setMeshResolution,
   laneWidth,
   setLaneWidth,
+  buildingFillSettings,
+  setBuildingFillSettings,
+  visibilitySettings,
+  setVisibilitySettings,
+  onGenerateBuildingFill,
   nodes,
   setNodes,
   edges,
@@ -81,6 +93,8 @@ export default function Sidebar({
   setSelectedEdges,
   buildings,
   setBuildings,
+  polygonFills,
+  selectedPolygonFillId,
   selectedBuildingId,
   selectedBuildingVertex,
   setSelectedBuildingId,
@@ -100,6 +114,23 @@ export default function Sidebar({
   const [globalScaleRoads, setGlobalScaleRoads] = useState<string>("1.5");
   const [globalScaleSidewalks, setGlobalScaleSidewalks] = useState<string>("1.5");
   const selectedBuilding = buildings.find((building) => building.id === selectedBuildingId) || null;
+  const selectedPolygonFill = polygonFills.find((fill) => fill.id === selectedPolygonFillId) || null;
+  const buildingFillSliderRanges = {
+    minWidth: Math.max(300, buildingFillSettings.minWidth),
+    maxWidth: Math.max(300, buildingFillSettings.maxWidth),
+    minHeight: Math.max(500, buildingFillSettings.minHeight),
+    maxHeight: Math.max(500, buildingFillSettings.maxHeight),
+  };
+  const updateVisibilitySetting = (key: keyof VisibilitySettings, value: boolean) => {
+    setVisibilitySettings(prev => ({ ...prev, [key]: value }));
+  };
+  const updateBuildingFillSetting = (key: keyof BuildingFillSettings, value: string) => {
+    const parsed = parseFloat(value);
+    setBuildingFillSettings(prev => sanitizeBuildingFillSettings({
+      ...prev,
+      [key]: Number.isFinite(parsed) ? parsed : prev[key],
+    }));
+  };
 
   const applyGlobalScaleMap = () => {
     const scale = parseFloat(globalScaleMap);
@@ -325,6 +356,14 @@ export default function Sidebar({
                     {isBuildingMode ? 'Building Mode: ON' : 'Add Building'}
                   </button>
               </div>
+              <div className="flex gap-2 mt-2">
+                  <button
+                      onClick={onGenerateBuildingFill}
+                      className="flex-1 px-3 py-1.5 rounded text-sm font-semibold flex justify-center items-center gap-2 transition-colors bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
+                  >
+                    Building Fill
+                  </button>
+              </div>
             </section>
 
 
@@ -425,12 +464,26 @@ export default function Sidebar({
           </div>
           {!collapsedSections['selected_items'] && (
             <div className="space-y-3 overflow-y-auto pb-4">
-              {selectedNodes.length === 0 && selectedEdges.length === 0 && !selectedBuilding ? (
+              {selectedNodes.length === 0 && selectedEdges.length === 0 && !selectedBuilding && !selectedPolygonFill ? (
                 <div className="text-sm text-slate-500 text-center py-4 px-4 bg-slate-800/10 rounded-lg border border-slate-800/50 border-dashed">
-                  Select a junction, road, or building in the viewport.
+                  Select a junction, road, polygon fill, or building in the viewport.
                 </div>
               ) : (
                 <>
+                  {selectedPolygonFill && (
+                    <div className="p-3 bg-emerald-900/10 rounded-xl border border-emerald-500/50 flex flex-col gap-2">
+                      <div className="flex justify-between items-center text-sm font-bold text-slate-200">
+                        <span>Polygon Fill {selectedPolygonFill.id.substring(0, 4)}</span>
+                        <span
+                          className="w-5 h-5 rounded border border-slate-700"
+                          style={{ backgroundColor: selectedPolygonFill.color }}
+                        />
+                      </div>
+                      <div className="text-xs text-emerald-100/80 bg-emerald-950/40 border border-emerald-900 rounded p-2">
+                        Building Fill will use these {selectedPolygonFill.points.length} polygon control points.
+                      </div>
+                    </div>
+                  )}
                   {selectedBuilding && (
                     <div className="p-3 bg-orange-900/10 rounded-xl border border-orange-500/50 flex flex-col gap-3">
                       <div className="flex justify-between items-center text-sm font-bold text-slate-200">
@@ -846,6 +899,72 @@ export default function Sidebar({
                   />
                 </div>
               </div>
+              <div className="pt-3 border-t border-slate-800">
+                <label className="block text-sm font-medium text-slate-300 mb-2">Building Fill Size</label>
+                <div className="space-y-3">
+                  {[
+                    ['minWidth', 'Min Width', buildingFillSliderRanges.minWidth],
+                    ['maxWidth', 'Max Width', buildingFillSliderRanges.maxWidth],
+                    ['minHeight', 'Min Height', buildingFillSliderRanges.minHeight],
+                    ['maxHeight', 'Max Height', buildingFillSliderRanges.maxHeight],
+                  ].map(([key, label, maxValue]) => (
+                    <div key={key}>
+                      <label className="text-xs text-slate-400 block mb-1">
+                        {label} ({buildingFillSettings[key as keyof BuildingFillSettings]}px)
+                      </label>
+                      <div className="flex gap-2 items-center">
+                        <input
+                          type="range"
+                          min="1"
+                          max={maxValue as number}
+                          step="1"
+                          value={buildingFillSettings[key as keyof BuildingFillSettings]}
+                          onChange={(e) => updateBuildingFillSetting(key as keyof BuildingFillSettings, e.target.value)}
+                          className="flex-grow min-w-0"
+                        />
+                        <input
+                          type="number"
+                          min="1"
+                          value={buildingFillSettings[key as keyof BuildingFillSettings]}
+                          onChange={(e) => updateBuildingFillSetting(key as keyof BuildingFillSettings, e.target.value)}
+                          className="w-16 bg-slate-800 border bg-transparent text-white border-slate-700 rounded p-1 text-sm text-center"
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section>
+          <div
+            className="flex items-center justify-between cursor-pointer mb-2"
+            onClick={() => toggleSection('visibility')}
+          >
+            <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">Visibility</h3>
+            {collapsedSections['visibility'] ? <ChevronRight className="w-4 h-4 text-slate-500" /> : <ChevronDown className="w-4 h-4 text-slate-500" />}
+          </div>
+          {!collapsedSections['visibility'] && (
+            <div className="space-y-3 bg-slate-800/20 p-3 rounded-lg border border-slate-800/50">
+              {[
+                ['showNodeHandles', 'Show Node Handles'],
+                ['showNodeControlPoints', 'Show Node Control Points'],
+                ['showPolyFillHandles', 'Show Poly Fill Handles'],
+                ['showBuildingHandles', 'Show Building Handles'],
+                ['showBuildingControlPoints', 'Show Building Control Points'],
+              ].map(([key, label]) => (
+                <label key={key} className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={visibilitySettings[key as keyof VisibilitySettings]}
+                    onChange={(event) => updateVisibilitySetting(key as keyof VisibilitySettings, event.target.checked)}
+                    className="w-4 h-4 rounded bg-slate-800 border-slate-700 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                  />
+                  <span>{label}</span>
+                </label>
+              ))}
             </div>
           )}
         </section>

--- a/tools/intersection-visualizer/src/components/three/ActualMesh.tsx
+++ b/tools/intersection-visualizer/src/components/three/ActualMesh.tsx
@@ -43,6 +43,15 @@ export function ActualMesh({ mesh, showMesh, debugOptions }: { mesh: any, showMe
     }));
   }, [mesh.polygonTriangles]);
 
+  const buildingGeos = useMemo(() => {
+    if (!mesh.buildingMeshes) return [];
+    return mesh.buildingMeshes.map((building: { triangles: Point[][], color: string, id: string }) => ({
+      id: building.id,
+      geo: createGeo(building.triangles),
+      color: building.color
+    }));
+  }, [mesh.buildingMeshes]);
+
   const wireColor = showMesh ? "#22d3ee" : undefined;
 
   const showRoads = debugOptions?.roads !== false;
@@ -51,9 +60,15 @@ export function ActualMesh({ mesh, showMesh, debugOptions }: { mesh: any, showMe
   const showCrossroads = debugOptions?.crossroads !== false;
   const showLines = debugOptions?.lines !== false;
   const showPolyFills = debugOptions?.polyFills !== false;
+  const showBuildings = debugOptions?.buildings !== false;
 
   return (
     <group>
+      {showBuildings && buildingGeos.map((building: any) => (
+        <mesh key={`building-mesh-${building.id}`} geometry={building.geo} position={[0, 0, 0]}>
+          <meshStandardMaterial color={wireColor || building.color} side={THREE.DoubleSide} wireframe={showMesh} roughness={0.7} />
+        </mesh>
+      ))}
       {showPolyFills && polygonGeos.map((pg: any, i: number) => (
         <mesh key={`poly-${i}`} geometry={pg.geo} position={[0, -1.5, 0]}>
           <meshStandardMaterial color={wireColor || pg.color} side={THREE.DoubleSide} wireframe={showMesh} transparent={true} opacity={0.7} />

--- a/tools/intersection-visualizer/src/components/three/PointerInterceptor.tsx
+++ b/tools/intersection-visualizer/src/components/three/PointerInterceptor.tsx
@@ -2,10 +2,11 @@ import React, { useEffect } from 'react';
 import { useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
+import { getBuildingBaseZ, getBuildingCenter, getBuildingHeight } from '../../lib/buildings';
 
 export function PointerInterceptor({
    onPointerDown, onPointerMove, onPointerUp, onContextMenu, onPointerCancel,
-   isDragging, initialCameraParams, controlsRef, draggingPoint, nodes, edges, selectedNode
+   isDragging, initialCameraParams, controlsRef, draggingPoint, nodes, edges, buildings, selectedNode
 }: any) {
    const { camera, raycaster, gl } = useThree();
 
@@ -63,6 +64,13 @@ export function PointerInterceptor({
                edges.forEach((e: any) => {
                   e.points.forEach((p: any) => checkPt(p));
                });
+               (buildings || []).forEach((building: any) => {
+                  const baseZ = getBuildingBaseZ(building);
+                  const height = getBuildingHeight(building);
+                  building.vertices.forEach((vertex: any) => checkPt({ x: vertex.x, y: vertex.y, z: baseZ }));
+                  const center = getBuildingCenter(building);
+                  checkPt({ x: center.x, y: center.y, z: baseZ + height });
+               });
 
                if (closestPt) currentY = closestPt.y;
             }
@@ -116,7 +124,7 @@ export function PointerInterceptor({
          gl.domElement.removeEventListener('contextmenu', ctx);
          gl.domElement.removeEventListener('pointercancel', cancel);
       };
-   }, [camera, raycaster, gl, onPointerDown, onPointerMove, onPointerUp, onContextMenu, onPointerCancel, isDragging, draggingPoint, nodes, edges, selectedNode]);
+   }, [camera, raycaster, gl, onPointerDown, onPointerMove, onPointerUp, onContextMenu, onPointerCancel, isDragging, draggingPoint, nodes, edges, buildings, selectedNode]);
 
    return <OrbitControls
       ref={controlsRef}

--- a/tools/intersection-visualizer/src/components/three/PointerInterceptor.tsx
+++ b/tools/intersection-visualizer/src/components/three/PointerInterceptor.tsx
@@ -6,7 +6,7 @@ import { getBuildingBaseZ, getBuildingCenter, getBuildingHeight } from '../../li
 
 export function PointerInterceptor({
    onPointerDown, onPointerMove, onPointerUp, onContextMenu, onPointerCancel,
-   isDragging, initialCameraParams, controlsRef, draggingPoint, nodes, edges, buildings, selectedNode
+   isDragging, initialCameraParams, controlsRef, draggingPoint, nodes, edges, buildings, selectedNode, visibilitySettings
 }: any) {
    const { camera, raycaster, gl } = useThree();
 
@@ -60,16 +60,24 @@ export function PointerInterceptor({
                   }
                };
 
-               nodes.forEach((n: any) => checkPt(n.point));
-               edges.forEach((e: any) => {
-                  e.points.forEach((p: any) => checkPt(p));
-               });
+               if (visibilitySettings.showNodeHandles) {
+                  nodes.forEach((n: any) => checkPt(n.point));
+               }
+               if (visibilitySettings.showNodeControlPoints) {
+                  edges.forEach((e: any) => {
+                     e.points.forEach((p: any) => checkPt(p));
+                  });
+               }
                (buildings || []).forEach((building: any) => {
                   const baseZ = getBuildingBaseZ(building);
                   const height = getBuildingHeight(building);
-                  building.vertices.forEach((vertex: any) => checkPt({ x: vertex.x, y: vertex.y, z: baseZ }));
-                  const center = getBuildingCenter(building);
-                  checkPt({ x: center.x, y: center.y, z: baseZ + height });
+                  if (visibilitySettings.showBuildingControlPoints) {
+                     building.vertices.forEach((vertex: any) => checkPt({ x: vertex.x, y: vertex.y, z: baseZ }));
+                  }
+                  if (visibilitySettings.showBuildingHandles) {
+                     const center = getBuildingCenter(building);
+                     checkPt({ x: center.x, y: center.y, z: baseZ + height });
+                  }
                });
 
                if (closestPt) currentY = closestPt.y;
@@ -124,7 +132,7 @@ export function PointerInterceptor({
          gl.domElement.removeEventListener('contextmenu', ctx);
          gl.domElement.removeEventListener('pointercancel', cancel);
       };
-   }, [camera, raycaster, gl, onPointerDown, onPointerMove, onPointerUp, onContextMenu, onPointerCancel, isDragging, draggingPoint, nodes, edges, buildings, selectedNode]);
+   }, [camera, raycaster, gl, onPointerDown, onPointerMove, onPointerUp, onContextMenu, onPointerCancel, isDragging, draggingPoint, nodes, edges, buildings, selectedNode, visibilitySettings]);
 
    return <OrbitControls
       ref={controlsRef}

--- a/tools/intersection-visualizer/src/components/three/SceneContent.tsx
+++ b/tools/intersection-visualizer/src/components/three/SceneContent.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import * as THREE from 'three';
 import { Node, Edge, Point } from '../../lib/types';
+import { getBuildingBaseZ, getBuildingCenter, getBuildingHeight } from '../../lib/buildings';
 import { CameraSync } from './CameraSync';
 import { PointerInterceptor } from './PointerInterceptor';
 import { BezierPaths } from './BezierPaths';
@@ -9,9 +10,9 @@ import { LaneArrows } from './LaneArrows';
 import { Grid } from '@react-three/drei';
 
 export function SceneContent({
-  mesh, showMesh, showControlPoints, nodes, edges, chamferAngle, polygonFills, selectedPolygonFillId,
+  mesh, showMesh, showControlPoints, nodes, edges, chamferAngle, polygonFills, buildings, selectedPolygonFillId,
   onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onContextMenu,
-  isDragging, draggingPoint, initialCameraParams, selectedNode, selectedNodes, selectedEdges, selectedPoints,
+  isDragging, draggingPoint, initialCameraParams, selectedNode, selectedNodes, selectedEdges, selectedPoints, selectedBuildingId, selectedBuildingVertex,
   softSelectionEnabled, softSelectionRadius,
   setView, containerRef, marqueeStart, marqueeEnd, snapGridSize = 10, debugOptions
 }: any) {
@@ -71,6 +72,7 @@ export function SceneContent({
         initialCameraParams={initialCameraParams}
         nodes={nodes}
         edges={edges}
+        buildings={buildings}
         selectedNode={selectedNode}
       />
 
@@ -113,6 +115,48 @@ export function SceneContent({
               <sphereGeometry args={[14, 16, 16]} />
               <meshBasicMaterial color={color} depthTest={false} depthWrite={false} transparent />
             </mesh>
+          );
+        })}
+
+        {buildings && buildings.map((building: any) => {
+          const center = getBuildingCenter(building);
+          const baseZ = getBuildingBaseZ(building);
+          const height = getBuildingHeight(building);
+          const isSelected = selectedBuildingId === building.id;
+          return (
+            <group key={`building-handles-${building.id}`}>
+              {building.vertices.map((vertex: Point, vertexIndex: number) => {
+                const isVertexSelected = selectedBuildingVertex?.buildingId === building.id && selectedBuildingVertex.vertexIndex === vertexIndex;
+                return (
+                  <mesh
+                    key={`building-${building.id}-vertex-${vertexIndex}`}
+                    position={[vertex.x, baseZ, vertex.y]}
+                    renderOrder={1000}
+                  >
+                    <boxGeometry args={[14, 14, 14]} />
+                    <meshBasicMaterial color={isVertexSelected ? '#f97316' : isSelected ? '#fdba74' : '#fb923c'} depthTest={false} depthWrite={false} transparent />
+                  </mesh>
+                );
+              })}
+              <mesh position={[center.x, baseZ + height, center.y]} renderOrder={1000}>
+                <sphereGeometry args={[isSelected ? 13 : 10, 16, 16]} />
+                <meshBasicMaterial color={isSelected && !selectedBuildingVertex ? '#ffffff' : '#f97316'} depthTest={false} depthWrite={false} transparent />
+              </mesh>
+              {isSelected && (
+                <lineSegments renderOrder={999}>
+                  <bufferGeometry>
+                    <bufferAttribute
+                      attach="attributes-position"
+                      args={[new Float32Array([
+                        center.x, baseZ, center.y,
+                        center.x, baseZ + height, center.y,
+                      ]), 3]}
+                    />
+                  </bufferGeometry>
+                  <lineBasicMaterial color="#f97316" transparent opacity={0.8} depthTest={false} depthWrite={false} />
+                </lineSegments>
+              )}
+            </group>
           );
         })}
 

--- a/tools/intersection-visualizer/src/components/three/SceneContent.tsx
+++ b/tools/intersection-visualizer/src/components/three/SceneContent.tsx
@@ -10,7 +10,7 @@ import { LaneArrows } from './LaneArrows';
 import { Grid } from '@react-three/drei';
 
 export function SceneContent({
-  mesh, showMesh, showControlPoints, nodes, edges, chamferAngle, polygonFills, buildings, selectedPolygonFillId,
+  mesh, showMesh, visibilitySettings, nodes, edges, chamferAngle, polygonFills, buildings, selectedPolygonFillId,
   onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onContextMenu,
   isDragging, draggingPoint, initialCameraParams, selectedNode, selectedNodes, selectedEdges, selectedPoints, selectedBuildingId, selectedBuildingVertex,
   softSelectionEnabled, softSelectionRadius,
@@ -74,11 +74,12 @@ export function SceneContent({
         edges={edges}
         buildings={buildings}
         selectedNode={selectedNode}
+        visibilitySettings={visibilitySettings}
       />
 
       <group>
-        {showControlPoints && <BezierPaths edges={edges} nodes={nodes} chamferAngle={chamferAngle} />}
-        {polygonFills && polygonFills.map((fill: any, i: number) => {
+        {visibilitySettings.showNodeControlPoints && <BezierPaths edges={edges} nodes={nodes} chamferAngle={chamferAngle} />}
+        {visibilitySettings.showPolyFillHandles && polygonFills && polygonFills.map((fill: any, i: number) => {
           let cx = 0, cy = 0, count = 0;
           fill.points.forEach((nid: string) => {
              const n = nodes.find((nn: any) => nn.id === nid);
@@ -102,7 +103,7 @@ export function SceneContent({
           }
           return null;
         })}
-        {nodes.map((n: Node) => {
+        {visibilitySettings.showNodeHandles && nodes.map((n: Node) => {
           const isActive = selectedNode === n.id;
           const isSelected = selectedNodes?.includes(n.id) || isActive;
           const color = isActive ? (n.point.linked ? '#059669' : '#ef4444') : isSelected ? (n.point.linked ? '#6ee7b7' : '#fca5a5') : (n.point.linked ? '#10b981' : '#60a5fa');
@@ -125,7 +126,7 @@ export function SceneContent({
           const isSelected = selectedBuildingId === building.id;
           return (
             <group key={`building-handles-${building.id}`}>
-              {building.vertices.map((vertex: Point, vertexIndex: number) => {
+              {visibilitySettings.showBuildingControlPoints && building.vertices.map((vertex: Point, vertexIndex: number) => {
                 const isVertexSelected = selectedBuildingVertex?.buildingId === building.id && selectedBuildingVertex.vertexIndex === vertexIndex;
                 return (
                   <mesh
@@ -138,11 +139,13 @@ export function SceneContent({
                   </mesh>
                 );
               })}
-              <mesh position={[center.x, baseZ + height, center.y]} renderOrder={1000}>
-                <sphereGeometry args={[isSelected ? 13 : 10, 16, 16]} />
-                <meshBasicMaterial color={isSelected && !selectedBuildingVertex ? '#ffffff' : '#f97316'} depthTest={false} depthWrite={false} transparent />
-              </mesh>
-              {isSelected && (
+              {visibilitySettings.showBuildingHandles && (
+                <mesh position={[center.x, baseZ + height, center.y]} renderOrder={1000}>
+                  <sphereGeometry args={[isSelected ? 13 : 10, 16, 16]} />
+                  <meshBasicMaterial color={isSelected && !selectedBuildingVertex ? '#ffffff' : '#f97316'} depthTest={false} depthWrite={false} transparent />
+                </mesh>
+              )}
+              {isSelected && visibilitySettings.showBuildingHandles && (
                 <lineSegments renderOrder={999}>
                   <bufferGeometry>
                     <bufferAttribute
@@ -163,7 +166,7 @@ export function SceneContent({
         {edges.flatMap((edge: Edge) =>
           edge.points.map((pt: Point, i: number) => {
             const isAnchor = (i % 3 === 2);
-            if (!showControlPoints && !isAnchor) return null;
+            if (!visibilitySettings.showNodeControlPoints) return null;
             const isSelectedEdge = selectedEdges.includes(edge.id);
             const isSelectedPoint = selectedPoints?.some((p: any) => p.edgeId === edge.id && p.pointIndex === i) || false;
 

--- a/tools/intersection-visualizer/src/lib/buildingFill.ts
+++ b/tools/intersection-visualizer/src/lib/buildingFill.ts
@@ -1,4 +1,5 @@
 import { DEFAULTS, sanitizeBuildingFillSettings } from './constants';
+import { getLowestPointZ } from './buildings';
 import { segmentIntersect } from './math';
 import { buildNetworkMesh } from './meshing';
 import { findClosedAreas } from './network';
@@ -521,6 +522,14 @@ function offsetPoint(point: Point, normal: Point, distance: number): Point {
   };
 }
 
+function footprintPoint(point: Point, z = point.z): Point {
+  const next: Point = { x: point.x, y: point.y };
+  if (typeof z === 'number' && Number.isFinite(z)) {
+    next.z = z;
+  }
+  return next;
+}
+
 function averagePoint(points: Point[]) {
   const sum = points.reduce((acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }), { x: 0, y: 0 });
   return { x: sum.x / points.length, y: sum.y / points.length };
@@ -630,11 +639,15 @@ function buildStripCandidate(frontCurve: Point[], side: CurveSide, depth: number
   const backA = offsetPoint(frontA, normal, depth);
 
   return [
-    { x: frontA.x, y: frontA.y },
-    { x: frontB.x, y: frontB.y },
-    { x: backB.x, y: backB.y },
-    { x: backA.x, y: backA.y },
+    footprintPoint(frontA),
+    footprintPoint(frontB),
+    footprintPoint(backB, frontB.z),
+    footprintPoint(backA, frontA.z),
   ];
+}
+
+function getBuildingFillBaseZ(frontCurve: Point[], vertices: Point[]) {
+  return getLowestPointZ([...frontCurve, ...vertices], DEFAULTS.buildingBaseZ);
 }
 
 function buildDepthCandidates(preferredDepth: number, settings: BuildingFillSettings) {
@@ -719,11 +732,10 @@ function generateBuildingsAlongCurve(options: {
     }
 
     if (acceptedVertices) {
-      const averageZ = frontCurve.reduce((sum, point) => sum + (point.z ?? DEFAULTS.buildingBaseZ), 0) / frontCurve.length;
       const building: BuildingPolygon = {
         id: makeBuildingId(`${options.seed}:${index}`, options.usedIds),
         vertices: acceptedVertices,
-        baseZ: averageZ,
+        baseZ: getBuildingFillBaseZ(frontCurve, acceptedVertices),
         height,
         color: DEFAULTS.buildingColor,
         material: DEFAULTS.buildingMaterial,
@@ -777,11 +789,10 @@ function tryCreateClosedCornerBuilding(options: {
       if (hasBuildingOverlap(vertices, options.occupied)) continue;
 
       const heightRandom = createRandom(`${options.seed}:height`);
-      const averageZ = options.frontCurve.reduce((sum, point) => sum + (point.z ?? DEFAULTS.buildingBaseZ), 0) / options.frontCurve.length;
       return {
         id: makeBuildingId(options.seed, options.usedIds),
         vertices,
-        baseZ: averageZ,
+        baseZ: getBuildingFillBaseZ(options.frontCurve, vertices),
         height: Math.round(randomRange(heightRandom, options.settings.minHeight, options.settings.maxHeight)),
         color: DEFAULTS.buildingColor,
         material: DEFAULTS.buildingMaterial,
@@ -890,12 +901,11 @@ function generateClosedBoundaryBuildings(options: {
 
       if (!acceptedVertices) continue;
 
-      const averageZ = frontCurve.reduce((sum, point) => sum + (point.z ?? DEFAULTS.buildingBaseZ), 0) / frontCurve.length;
       const heightRandom = createRandom(`${buildingSeed}:height`);
       const building: BuildingPolygon = {
         id: makeBuildingId(buildingSeed, options.usedIds),
         vertices: acceptedVertices,
-        baseZ: averageZ,
+        baseZ: getBuildingFillBaseZ(frontCurve, acceptedVertices),
         height: Math.round(randomRange(heightRandom, options.settings.minHeight, options.settings.maxHeight)),
         color: DEFAULTS.buildingColor,
         material: DEFAULTS.buildingMaterial,

--- a/tools/intersection-visualizer/src/lib/buildingFill.ts
+++ b/tools/intersection-visualizer/src/lib/buildingFill.ts
@@ -1,0 +1,1180 @@
+import { DEFAULTS, sanitizeBuildingFillSettings } from './constants';
+import { segmentIntersect } from './math';
+import { buildNetworkMesh } from './meshing';
+import { findClosedAreas } from './network';
+import type { BuildingFillSettings, BuildingPolygon, Edge, MeshData, Node, Point } from './types';
+
+type RoadPolygon = MeshData['roadPolygons'][number];
+
+type BuildingFillParams = {
+  nodes: Node[];
+  edges: Edge[];
+  selectedNodes: string[];
+  selectedEdges: string[];
+  buildings: BuildingPolygon[];
+  chamferAngle: number;
+  meshResolution: number;
+  laneWidth: number;
+  settings: BuildingFillSettings;
+  seedSalt?: string;
+};
+
+type BuildingFillResult = {
+  buildings: BuildingPolygon[];
+  mode: 'closed' | 'open' | 'none';
+};
+
+type FillBoundary = {
+  polygon: Point[];
+  centroid: Point;
+  edgeSegments?: Point[][];
+};
+
+type CurveSide = 'left' | 'right';
+
+const MIN_CURVE_LENGTH = 1;
+const BOUNDARY_EPSILON = 0.1;
+
+function hashString(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function createRandom(seed: string) {
+  let state = hashString(seed);
+  return () => {
+    state += 0x6d2b79f5;
+    let next = state;
+    next = Math.imul(next ^ (next >>> 15), next | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomRange(random: () => number, min: number, max: number) {
+  if (max <= min) return min;
+  return min + (max - min) * random();
+}
+
+function makeBuildingId(seed: string, usedIds: Set<string>) {
+  const base = `bf_${hashString(seed).toString(36)}`;
+  let id = base;
+  let suffix = 2;
+  while (usedIds.has(id)) {
+    id = `${base}_${suffix}`;
+    suffix++;
+  }
+  usedIds.add(id);
+  return id;
+}
+
+function pointDistanceToSegment(point: Point, a: Point, b: Point) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq < 0.0001) return Math.hypot(point.x - a.x, point.y - a.y);
+  const t = Math.max(0, Math.min(1, ((point.x - a.x) * dx + (point.y - a.y) * dy) / lenSq));
+  return Math.hypot(point.x - (a.x + dx * t), point.y - (a.y + dy * t));
+}
+
+function pointDistance(a: Point, b: Point) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function pointInPolygon(point: Point, polygon: Point[]) {
+  if (polygon.length < 3) return false;
+
+  for (let index = 0; index < polygon.length; index++) {
+    if (pointDistanceToSegment(point, polygon[index], polygon[(index + 1) % polygon.length]) <= BOUNDARY_EPSILON) {
+      return true;
+    }
+  }
+
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const pi = polygon[i];
+    const pj = polygon[j];
+    if (
+      (pi.y > point.y) !== (pj.y > point.y) &&
+      point.x < ((pj.x - pi.x) * (point.y - pi.y)) / (pj.y - pi.y) + pi.x
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function pointStrictlyInPolygon(point: Point, polygon: Point[]) {
+  if (polygon.length < 3) return false;
+
+  for (let index = 0; index < polygon.length; index++) {
+    if (pointDistanceToSegment(point, polygon[index], polygon[(index + 1) % polygon.length]) <= BOUNDARY_EPSILON) {
+      return false;
+    }
+  }
+
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const pi = polygon[i];
+    const pj = polygon[j];
+    if (
+      (pi.y > point.y) !== (pj.y > point.y) &&
+      point.x < ((pj.x - pi.x) * (point.y - pi.y)) / (pj.y - pi.y) + pi.x
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function polygonCentroid(polygon: Point[]): Point {
+  let signedArea = 0;
+  let cx = 0;
+  let cy = 0;
+
+  for (let index = 0; index < polygon.length; index++) {
+    const current = polygon[index];
+    const next = polygon[(index + 1) % polygon.length];
+    const cross = current.x * next.y - next.x * current.y;
+    signedArea += cross;
+    cx += (current.x + next.x) * cross;
+    cy += (current.y + next.y) * cross;
+  }
+
+  if (Math.abs(signedArea) > 0.0001) {
+    const factor = 1 / (3 * signedArea);
+    return { x: cx * factor, y: cy * factor };
+  }
+
+  const sum = polygon.reduce((acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }), { x: 0, y: 0 });
+  return { x: sum.x / polygon.length, y: sum.y / polygon.length };
+}
+
+function polygonBounds(polygon: Point[]) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  polygon.forEach((point) => {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  });
+
+  return { minX, minY, maxX, maxY };
+}
+
+function polygonsOverlap(a: Point[], b: Point[]) {
+  if (a.length < 3 || b.length < 3) return false;
+
+  const boundsA = polygonBounds(a);
+  const boundsB = polygonBounds(b);
+  if (
+    boundsA.maxX < boundsB.minX ||
+    boundsB.maxX < boundsA.minX ||
+    boundsA.maxY < boundsB.minY ||
+    boundsB.maxY < boundsA.minY
+  ) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    const a0 = a[i];
+    const a1 = a[(i + 1) % a.length];
+    for (let j = 0; j < b.length; j++) {
+      const b0 = b[j];
+      const b1 = b[(j + 1) % b.length];
+      const intersection = segmentIntersect(a0, a1, b0, b1);
+      if (
+        intersection &&
+        pointDistance(intersection, a0) > BOUNDARY_EPSILON &&
+        pointDistance(intersection, a1) > BOUNDARY_EPSILON &&
+        pointDistance(intersection, b0) > BOUNDARY_EPSILON &&
+        pointDistance(intersection, b1) > BOUNDARY_EPSILON
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return (
+    pointStrictlyInPolygon(a[0], b) ||
+    pointStrictlyInPolygon(b[0], a) ||
+    pointStrictlyInPolygon(averagePoint(a), b) ||
+    pointStrictlyInPolygon(averagePoint(b), a)
+  );
+}
+
+function isSimplePolygon(polygon: Point[]) {
+  for (let i = 0; i < polygon.length; i++) {
+    const a0 = polygon[i];
+    const a1 = polygon[(i + 1) % polygon.length];
+
+    for (let j = i + 1; j < polygon.length; j++) {
+      if (Math.abs(i - j) <= 1 || (i === 0 && j === polygon.length - 1)) continue;
+
+      const b0 = polygon[j];
+      const b1 = polygon[(j + 1) % polygon.length];
+      const intersection = segmentIntersect(a0, a1, b0, b1);
+      if (
+        intersection &&
+        pointDistance(intersection, a0) > BOUNDARY_EPSILON &&
+        pointDistance(intersection, a1) > BOUNDARY_EPSILON &&
+        pointDistance(intersection, b0) > BOUNDARY_EPSILON &&
+        pointDistance(intersection, b1) > BOUNDARY_EPSILON
+      ) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function isValidBuildingFootprint(vertices: Point[]) {
+  if (vertices.length < 3) return false;
+  if (vertices.some((vertex) => !Number.isFinite(vertex.x) || !Number.isFinite(vertex.y))) return false;
+  if (Math.abs(polygonSignedArea(vertices)) <= 1) return false;
+  return isSimplePolygon(vertices);
+}
+
+function meetsMinimumFootprintSize(vertices: Point[], settings: BuildingFillSettings) {
+  return vertices.every((vertex, index) => (
+    pointDistance(vertex, vertices[(index + 1) % vertices.length]) >= settings.minWidth - BOUNDARY_EPSILON
+  ));
+}
+
+function getPolylineLength(curve: Point[]) {
+  let length = 0;
+  for (let index = 1; index < curve.length; index++) {
+    length += Math.hypot(curve[index].x - curve[index - 1].x, curve[index].y - curve[index - 1].y);
+  }
+  return length;
+}
+
+function getFillSegmentCount(totalLength: number, settings: BuildingFillSettings) {
+  if (totalLength <= MIN_CURVE_LENGTH) return 0;
+
+  const averageWidth = (settings.minWidth + settings.maxWidth) / 2;
+  let count = Math.max(1, Math.round(totalLength / Math.max(averageWidth, 1)));
+
+  if (totalLength / count > settings.maxWidth) {
+    count = Math.ceil(totalLength / settings.maxWidth);
+  }
+
+  if (count > 1 && totalLength / count < settings.minWidth) {
+    count = Math.max(1, Math.floor(totalLength / settings.minWidth));
+  }
+
+  return count;
+}
+
+function samplePolyline(curve: Point[], distance: number) {
+  let remaining = Math.max(0, distance);
+  for (let index = 1; index < curve.length; index++) {
+    const previous = curve[index - 1];
+    const current = curve[index];
+    const dx = current.x - previous.x;
+    const dy = current.y - previous.y;
+    const length = Math.hypot(dx, dy);
+    if (length <= 0.0001) continue;
+
+    if (remaining <= length || index === curve.length - 1) {
+      const t = Math.max(0, Math.min(1, remaining / length));
+      return {
+        point: {
+          x: previous.x + dx * t,
+          y: previous.y + dy * t,
+          z: (previous.z ?? DEFAULTS.buildingBaseZ) + ((current.z ?? DEFAULTS.buildingBaseZ) - (previous.z ?? DEFAULTS.buildingBaseZ)) * t,
+        },
+        tangent: { x: dx / length, y: dy / length },
+      };
+    }
+
+    remaining -= length;
+  }
+
+  const first = curve[0] ?? { x: 0, y: 0 };
+  const last = curve[curve.length - 1] ?? first;
+  const dx = last.x - first.x;
+  const dy = last.y - first.y;
+  const length = Math.hypot(dx, dy) || 1;
+  return {
+    point: { ...last },
+    tangent: { x: dx / length, y: dy / length },
+  };
+}
+
+function getPointDistances(curve: Point[]) {
+  const distances = [0];
+  for (let index = 1; index < curve.length; index++) {
+    distances.push(distances[index - 1] + pointDistance(curve[index], curve[index - 1]));
+  }
+  return distances;
+}
+
+function slicePolyline(curve: Point[], startDistance: number, endDistance: number) {
+  if (curve.length < 2) return [...curve];
+
+  const distances = getPointDistances(curve);
+  const totalLength = distances[distances.length - 1];
+  const start = Math.max(0, Math.min(totalLength, startDistance));
+  const end = Math.max(start, Math.min(totalLength, endDistance));
+  const result: Point[] = [samplePolyline(curve, start).point];
+
+  for (let index = 1; index < curve.length - 1; index++) {
+    if (distances[index] > start + BOUNDARY_EPSILON && distances[index] < end - BOUNDARY_EPSILON) {
+      result.push({ ...curve[index] });
+    }
+  }
+
+  const endPoint = samplePolyline(curve, end).point;
+  const previous = result[result.length - 1];
+  if (!previous || pointDistance(previous, endPoint) > BOUNDARY_EPSILON) {
+    result.push(endPoint);
+  }
+
+  return result;
+}
+
+function getClosedCurve(polygon: Point[]) {
+  if (polygon.length === 0) return [];
+  return [...polygon, polygon[0]];
+}
+
+function isSharpBoundaryTurn(previous: Point, current: Point, next: Point) {
+  const dx1 = current.x - previous.x;
+  const dy1 = current.y - previous.y;
+  const dx2 = next.x - current.x;
+  const dy2 = next.y - current.y;
+  const len1 = Math.hypot(dx1, dy1);
+  const len2 = Math.hypot(dx2, dy2);
+  if (len1 <= BOUNDARY_EPSILON || len2 <= BOUNDARY_EPSILON) return false;
+
+  const dot = (dx1 * dx2 + dy1 * dy2) / (len1 * len2);
+  return dot < Math.cos(Math.PI / 4);
+}
+
+function splitClosedBoundaryIntoRuns(polygon: Point[]) {
+  if (polygon.length < 3) return [];
+
+  const breakpoints: number[] = [];
+  for (let index = 0; index < polygon.length; index++) {
+    const previous = polygon[(index - 1 + polygon.length) % polygon.length];
+    const current = polygon[index];
+    const next = polygon[(index + 1) % polygon.length];
+    if (isSharpBoundaryTurn(previous, current, next)) {
+      breakpoints.push(index);
+    }
+  }
+
+  if (breakpoints.length === 0) {
+    return [getClosedCurve(polygon)];
+  }
+
+  return breakpoints.flatMap((startIndex, breakpointIndex) => {
+    const endIndex = breakpoints[(breakpointIndex + 1) % breakpoints.length];
+    const run: Point[] = [polygon[startIndex]];
+    let index = (startIndex + 1) % polygon.length;
+    let guard = 0;
+
+    while (guard < polygon.length + 1) {
+      run.push(polygon[index]);
+      if (index === endIndex) break;
+      index = (index + 1) % polygon.length;
+      guard++;
+    }
+
+    return getPolylineLength(run) > MIN_CURVE_LENGTH ? [run] : [];
+  });
+}
+
+function closestPointOnSegment(point: Point, a: Point, b: Point) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq < 0.0001) {
+    return {
+      point: a,
+      distance: pointDistance(point, a),
+      t: 0,
+    };
+  }
+
+  const t = Math.max(0, Math.min(1, ((point.x - a.x) * dx + (point.y - a.y) * dy) / lenSq));
+  const closest = {
+    x: a.x + dx * t,
+    y: a.y + dy * t,
+    z: (a.z ?? DEFAULTS.buildingBaseZ) + ((b.z ?? DEFAULTS.buildingBaseZ) - (a.z ?? DEFAULTS.buildingBaseZ)) * t,
+  };
+
+  return {
+    point: closest,
+    distance: pointDistance(point, closest),
+    t,
+  };
+}
+
+function closestBoundaryPoint(point: Point, polygon: Point[], closed = true) {
+  let best = {
+    point,
+    segmentIndex: -1,
+    distance: Infinity,
+    t: 0,
+  };
+
+  const segmentCount = closed ? polygon.length : Math.max(polygon.length - 1, 0);
+  for (let index = 0; index < segmentCount; index++) {
+    const closest = closestPointOnSegment(point, polygon[index], polygon[(index + 1) % polygon.length]);
+    if (closest.distance < best.distance) {
+      best = {
+        point: closest.point,
+        segmentIndex: index,
+        distance: closest.distance,
+        t: closest.t,
+      };
+    }
+  }
+
+  return best;
+}
+
+function buildOpenBoundaryPath(hubPolygon: Point[], from: Point, to: Point): Point[] {
+  if (hubPolygon.length < 2) return [];
+
+  const fromBoundary = closestBoundaryPoint(from, hubPolygon, false);
+  const toBoundary = closestBoundaryPoint(to, hubPolygon, false);
+  if (fromBoundary.segmentIndex === -1 || toBoundary.segmentIndex === -1) return [];
+
+  const fromPosition = fromBoundary.segmentIndex + fromBoundary.t;
+  const toPosition = toBoundary.segmentIndex + toBoundary.t;
+  const path: Point[] = [fromBoundary.point];
+
+  if (fromPosition <= toPosition) {
+    for (let index = fromBoundary.segmentIndex + 1; index <= toBoundary.segmentIndex; index++) {
+      path.push(hubPolygon[index]);
+    }
+  } else {
+    for (let index = fromBoundary.segmentIndex; index > toBoundary.segmentIndex; index--) {
+      path.push(hubPolygon[index]);
+    }
+  }
+
+  path.push(toBoundary.point);
+  return path;
+}
+
+function buildHubBoundaryPath(hubPolygon: Point[], from: Point, to: Point, isClockwise: boolean, openBoundary = false): Point[] {
+  if (hubPolygon.length < 2) return [];
+  if (openBoundary) return buildOpenBoundaryPath(hubPolygon, from, to);
+
+  const fromBoundary = closestBoundaryPoint(from, hubPolygon);
+  const toBoundary = closestBoundaryPoint(to, hubPolygon);
+  if (fromBoundary.segmentIndex === -1 || toBoundary.segmentIndex === -1) return [];
+  if (fromBoundary.distance > 25 || toBoundary.distance > 25) return [];
+
+  const forwardPath: Point[] = [fromBoundary.point];
+  let forwardIndex = (fromBoundary.segmentIndex + 1) % hubPolygon.length;
+  const forwardStop = (toBoundary.segmentIndex + 1) % hubPolygon.length;
+  while (forwardIndex !== forwardStop && forwardPath.length < hubPolygon.length + 2) {
+    forwardPath.push(hubPolygon[forwardIndex]);
+    forwardIndex = (forwardIndex + 1) % hubPolygon.length;
+  }
+  forwardPath.push(toBoundary.point);
+
+  const backwardPath: Point[] = [fromBoundary.point];
+  let backwardIndex = fromBoundary.segmentIndex;
+  while (backwardIndex !== toBoundary.segmentIndex && backwardPath.length < hubPolygon.length + 2) {
+    backwardPath.push(hubPolygon[backwardIndex]);
+    backwardIndex = (backwardIndex - 1 + hubPolygon.length) % hubPolygon.length;
+  }
+  backwardPath.push(toBoundary.point);
+
+  const forwardLength = getPolylineLength(forwardPath);
+  const backwardLength = getPolylineLength(backwardPath);
+  if (Math.abs(forwardLength - backwardLength) > BOUNDARY_EPSILON) {
+    return forwardLength <= backwardLength ? forwardPath : backwardPath;
+  }
+
+  return isClockwise ? backwardPath : forwardPath;
+}
+
+function leftNormal(dir: Point) {
+  return { x: dir.y, y: -dir.x };
+}
+
+function rightNormal(dir: Point) {
+  return { x: -dir.y, y: dir.x };
+}
+
+function offsetPoint(point: Point, normal: Point, distance: number): Point {
+  return {
+    x: point.x + normal.x * distance,
+    y: point.y + normal.y * distance,
+    z: point.z,
+  };
+}
+
+function averagePoint(points: Point[]) {
+  const sum = points.reduce((acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }), { x: 0, y: 0 });
+  return { x: sum.x / points.length, y: sum.y / points.length };
+}
+
+function segmentMidpoint(a: Point, b: Point) {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+function hasBuildingOverlap(vertices: Point[], existingBuildings: BuildingPolygon[]) {
+  return existingBuildings.some((building) => polygonsOverlap(vertices, building.vertices));
+}
+
+function hasForbiddenOverlap(vertices: Point[], forbiddenPolygons: Point[][]) {
+  return forbiddenPolygons.some((polygon) => polygon.length >= 3 && polygonsOverlap(vertices, polygon));
+}
+
+function hasForbiddenInteriorPoint(vertices: Point[], forbiddenPolygons: Point[][]) {
+  const probes = [
+    averagePoint(vertices),
+    segmentMidpoint(vertices[2], vertices[3]),
+    vertices[2],
+    vertices[3],
+  ];
+
+  return probes.some((point) => (
+    forbiddenPolygons.some((polygon) => polygon.length >= 3 && pointStrictlyInPolygon(point, polygon))
+  ));
+}
+
+function buildingFitsInsideBoundary(vertices: Point[], boundary: Point[]) {
+  if (vertices.length < 3 || boundary.length < 3) return false;
+
+  if (!vertices.every((vertex) => pointInPolygon(vertex, boundary))) {
+    return false;
+  }
+
+  if (!pointInPolygon(averagePoint(vertices), boundary)) {
+    return false;
+  }
+
+  for (let index = 0; index < vertices.length; index++) {
+    const current = vertices[index];
+    const next = vertices[(index + 1) % vertices.length];
+    if (!pointInPolygon(segmentMidpoint(current, next), boundary)) {
+      return false;
+    }
+  }
+
+  for (let edgeIndex = 1; edgeIndex < vertices.length; edgeIndex++) {
+    const current = vertices[edgeIndex];
+    const next = vertices[(edgeIndex + 1) % vertices.length];
+
+    for (let boundaryIndex = 0; boundaryIndex < boundary.length; boundaryIndex++) {
+      const boundaryA = boundary[boundaryIndex];
+      const boundaryB = boundary[(boundaryIndex + 1) % boundary.length];
+      const intersection = segmentIntersect(current, next, boundaryA, boundaryB);
+      if (!intersection) continue;
+
+      const touchesBuildingEndpoint = (
+        pointDistance(intersection, current) <= BOUNDARY_EPSILON * 2 ||
+        pointDistance(intersection, next) <= BOUNDARY_EPSILON * 2
+      );
+      if (!touchesBuildingEndpoint) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function getLocalTangent(curve: Point[], index: number) {
+  const previous = curve[Math.max(0, index - 1)];
+  const next = curve[Math.min(curve.length - 1, index + 1)];
+  const dx = next.x - previous.x;
+  const dy = next.y - previous.y;
+  const length = Math.hypot(dx, dy);
+  return length > 0.0001 ? { x: dx / length, y: dy / length } : { x: 1, y: 0 };
+}
+
+function getEndpointTangent(curve: Point[], endpoint: 'start' | 'end') {
+  if (curve.length < 2) return { x: 1, y: 0 };
+  const a = endpoint === 'start' ? curve[0] : curve[curve.length - 2];
+  const b = endpoint === 'start' ? curve[1] : curve[curve.length - 1];
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const length = Math.hypot(dx, dy);
+  return length > 0.0001 ? { x: dx / length, y: dy / length } : getLocalTangent(curve, Math.floor((curve.length - 1) / 2));
+}
+
+function sideNormal(tangent: Point, side: CurveSide) {
+  return side === 'left' ? leftNormal(tangent) : rightNormal(tangent);
+}
+
+function buildStripCandidate(frontCurve: Point[], side: CurveSide, depth: number) {
+  const frontA = frontCurve[0];
+  const frontB = frontCurve[frontCurve.length - 1];
+  const dx = frontB.x - frontA.x;
+  const dy = frontB.y - frontA.y;
+  const chordLength = Math.hypot(dx, dy);
+  const tangent = chordLength > BOUNDARY_EPSILON
+    ? { x: dx / chordLength, y: dy / chordLength }
+    : getEndpointTangent(frontCurve, 'start');
+  const normal = sideNormal(tangent, side);
+  const backB = offsetPoint(frontB, normal, depth);
+  const backA = offsetPoint(frontA, normal, depth);
+
+  return [
+    { x: frontA.x, y: frontA.y },
+    { x: frontB.x, y: frontB.y },
+    { x: backB.x, y: backB.y },
+    { x: backA.x, y: backA.y },
+  ];
+}
+
+function buildDepthCandidates(preferredDepth: number, settings: BuildingFillSettings) {
+  const clampedPreferred = Math.max(settings.minWidth, Math.min(settings.maxWidth, preferredDepth));
+  const candidates = [
+    clampedPreferred,
+    settings.maxWidth,
+    clampedPreferred * 0.85,
+    clampedPreferred * 0.7,
+    clampedPreferred * 0.55,
+    settings.minWidth,
+  ];
+
+  return candidates.filter((depth, index) => (
+    depth >= settings.minWidth - BOUNDARY_EPSILON &&
+    candidates.findIndex((candidate) => Math.abs(candidate - depth) <= BOUNDARY_EPSILON) === index
+  ));
+}
+
+function chooseInteriorSide(frontCurve: Point[], boundary: FillBoundary): CurveSide {
+  const middle = samplePolyline(frontCurve, getPolylineLength(frontCurve) / 2);
+  const leftProbe = offsetPoint(middle.point, leftNormal(middle.tangent), 2);
+  const rightProbe = offsetPoint(middle.point, rightNormal(middle.tangent), 2);
+  const leftInside = pointInPolygon(leftProbe, boundary.polygon);
+  const rightInside = pointInPolygon(rightProbe, boundary.polygon);
+
+  if (leftInside !== rightInside) {
+    return leftInside ? 'left' : 'right';
+  }
+
+  return pointDistance(leftProbe, boundary.centroid) <= pointDistance(rightProbe, boundary.centroid)
+    ? 'left'
+    : 'right';
+}
+
+function generateBuildingsAlongCurve(options: {
+  curve: Point[];
+  side: CurveSide;
+  settings: BuildingFillSettings;
+  existingBuildings: BuildingPolygon[];
+  forbiddenPolygons: Point[][];
+  usedIds: Set<string>;
+  seed: string;
+}) {
+  const curve = options.curve.filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
+  const totalLength = getPolylineLength(curve);
+  if (curve.length < 2 || totalLength <= MIN_CURVE_LENGTH) return [];
+
+  const generated: BuildingPolygon[] = [];
+  const buildingCount = getFillSegmentCount(totalLength, options.settings);
+  const segmentLength = totalLength / buildingCount;
+
+  for (let index = 0; index < buildingCount; index++) {
+    const startDistance = index * segmentLength;
+    const endDistance = index === buildingCount - 1 ? totalLength : (index + 1) * segmentLength;
+    const frontCurve = slicePolyline(curve, startDistance, endDistance);
+    if (frontCurve.length < 2) continue;
+
+    const depthRandom = createRandom(`${options.seed}:${index}:depth`);
+    const heightRandom = createRandom(`${options.seed}:${index}:height`);
+    const requestedDepth = randomRange(depthRandom, options.settings.minWidth, options.settings.maxWidth);
+    const height = Math.round(randomRange(heightRandom, options.settings.minHeight, options.settings.maxHeight));
+    let acceptedVertices: Point[] | null = null;
+
+    const depths = [
+      requestedDepth,
+      requestedDepth * 0.8,
+      requestedDepth * 0.6,
+      requestedDepth * 0.4,
+      options.settings.minWidth,
+    ];
+
+    for (const depth of depths) {
+      if (depth < options.settings.minWidth) continue;
+      const vertices = buildStripCandidate(frontCurve, options.side, depth);
+      if (!isValidBuildingFootprint(vertices)) continue;
+      if (!meetsMinimumFootprintSize(vertices, options.settings)) continue;
+      if (hasForbiddenInteriorPoint(vertices, options.forbiddenPolygons)) continue;
+      if (hasBuildingOverlap(vertices, options.existingBuildings)) continue;
+      acceptedVertices = vertices;
+      break;
+    }
+
+    if (acceptedVertices) {
+      const averageZ = frontCurve.reduce((sum, point) => sum + (point.z ?? DEFAULTS.buildingBaseZ), 0) / frontCurve.length;
+      const building: BuildingPolygon = {
+        id: makeBuildingId(`${options.seed}:${index}`, options.usedIds),
+        vertices: acceptedVertices,
+        baseZ: averageZ,
+        height,
+        color: DEFAULTS.buildingColor,
+        material: DEFAULTS.buildingMaterial,
+      };
+      generated.push(building);
+    }
+  }
+
+  return generated;
+}
+
+function getCornerFrontage(curve: Point[], endpoint: 'start' | 'end', settings: BuildingFillSettings) {
+  const totalLength = getPolylineLength(curve);
+  if (curve.length < 2 || totalLength < settings.minWidth - BOUNDARY_EPSILON) return null;
+
+  const buildingCount = getFillSegmentCount(totalLength, settings);
+  if (buildingCount <= 0) return null;
+
+  const frontageLength = totalLength / buildingCount;
+  if (frontageLength < settings.minWidth - BOUNDARY_EPSILON) return null;
+
+  return endpoint === 'start'
+    ? slicePolyline(curve, 0, frontageLength)
+    : slicePolyline(curve, totalLength - frontageLength, totalLength);
+}
+
+function tryCreateClosedCornerBuilding(options: {
+  frontCurve: Point[];
+  boundary: FillBoundary;
+  settings: BuildingFillSettings;
+  occupied: BuildingPolygon[];
+  forbiddenPolygons: Point[][];
+  usedIds: Set<string>;
+  seed: string;
+}) {
+  const frontLength = getPolylineLength(options.frontCurve);
+  if (frontLength < options.settings.minWidth - BOUNDARY_EPSILON) return null;
+
+  const preferredSide = chooseInteriorSide(options.frontCurve, options.boundary);
+  const sides: CurveSide[] = preferredSide === 'left' ? ['left', 'right'] : ['right', 'left'];
+  const depthRandom = createRandom(`${options.seed}:depth`);
+  const preferredDepth = randomRange(depthRandom, options.settings.minWidth, options.settings.maxWidth);
+
+  for (const depth of buildDepthCandidates(preferredDepth, options.settings)) {
+    for (const side of sides) {
+      const vertices = buildStripCandidate(options.frontCurve, side, depth);
+      if (!isValidBuildingFootprint(vertices)) continue;
+      if (!meetsMinimumFootprintSize(vertices, options.settings)) continue;
+      if (!buildingFitsInsideBoundary(vertices, options.boundary.polygon)) continue;
+      if (hasForbiddenOverlap(vertices, options.forbiddenPolygons)) continue;
+      if (hasBuildingOverlap(vertices, options.occupied)) continue;
+
+      const heightRandom = createRandom(`${options.seed}:height`);
+      const averageZ = options.frontCurve.reduce((sum, point) => sum + (point.z ?? DEFAULTS.buildingBaseZ), 0) / options.frontCurve.length;
+      return {
+        id: makeBuildingId(options.seed, options.usedIds),
+        vertices,
+        baseZ: averageZ,
+        height: Math.round(randomRange(heightRandom, options.settings.minHeight, options.settings.maxHeight)),
+        color: DEFAULTS.buildingColor,
+        material: DEFAULTS.buildingMaterial,
+      } satisfies BuildingPolygon;
+    }
+  }
+
+  return null;
+}
+
+function generateClosedCornerBuildings(options: {
+  boundary: FillBoundary;
+  settings: BuildingFillSettings;
+  existingBuildings: BuildingPolygon[];
+  forbiddenPolygons: Point[][];
+  usedIds: Set<string>;
+  seed: string;
+}) {
+  const edgeSegments = options.boundary.edgeSegments ?? [];
+  if (edgeSegments.length < 2) return [];
+
+  const generated: BuildingPolygon[] = [];
+  const occupied = [...options.existingBuildings];
+
+  edgeSegments.forEach((outgoingSegment, cornerIndex) => {
+    const incomingSegment = edgeSegments[(cornerIndex - 1 + edgeSegments.length) % edgeSegments.length];
+    const cornerFrontages = [
+      { curve: getCornerFrontage(incomingSegment, 'end', options.settings), label: 'incoming' },
+      { curve: getCornerFrontage(outgoingSegment, 'start', options.settings), label: 'outgoing' },
+    ];
+
+    cornerFrontages.forEach((frontage) => {
+      if (!frontage.curve || frontage.curve.length < 2) return;
+
+      const building = tryCreateClosedCornerBuilding({
+        frontCurve: frontage.curve,
+        boundary: options.boundary,
+        settings: options.settings,
+        occupied,
+        forbiddenPolygons: options.forbiddenPolygons,
+        usedIds: options.usedIds,
+        seed: `${options.seed}:corner:${cornerIndex}:${frontage.label}`,
+      });
+
+      if (!building) return;
+      generated.push(building);
+      occupied.push(building);
+    });
+  });
+
+  return generated;
+}
+
+function generateClosedBoundaryBuildings(options: {
+  boundary: FillBoundary;
+  settings: BuildingFillSettings;
+  existingBuildings: BuildingPolygon[];
+  forbiddenPolygons: Point[][];
+  usedIds: Set<string>;
+  seed: string;
+}) {
+  const generated: BuildingPolygon[] = [];
+  const cornerBuildings = generateClosedCornerBuildings({
+    boundary: options.boundary,
+    settings: options.settings,
+    existingBuildings: options.existingBuildings,
+    forbiddenPolygons: options.forbiddenPolygons,
+    usedIds: options.usedIds,
+    seed: `${options.seed}:corners`,
+  });
+  generated.push(...cornerBuildings);
+
+  const edgeBlockingBuildings = [...options.existingBuildings, ...cornerBuildings];
+  const boundaryRuns = splitClosedBoundaryIntoRuns(options.boundary.polygon);
+
+  boundaryRuns.forEach((boundaryRun, runIndex) => {
+    const totalLength = getPolylineLength(boundaryRun);
+    if (boundaryRun.length < 2 || totalLength < MIN_CURVE_LENGTH) return;
+
+    const buildingCount = getFillSegmentCount(totalLength, options.settings);
+    const segmentLength = totalLength / buildingCount;
+
+    for (let index = 0; index < buildingCount; index++) {
+      const startDistance = index * segmentLength;
+      const endDistance = index === buildingCount - 1 ? totalLength : (index + 1) * segmentLength;
+      const frontCurve = slicePolyline(boundaryRun, startDistance, endDistance);
+      if (frontCurve.length < 2) continue;
+
+      const side = chooseInteriorSide(frontCurve, options.boundary);
+      const buildingSeed = `${options.seed}:${runIndex}:${index}`;
+      const depthRandom = createRandom(`${buildingSeed}:depth`);
+      const requestedDepth = randomRange(depthRandom, options.settings.minWidth, options.settings.maxWidth);
+      let acceptedVertices: Point[] | null = null;
+
+      for (const depth of buildDepthCandidates(requestedDepth, options.settings)) {
+        if (depth < 4) continue;
+        const vertices = buildStripCandidate(frontCurve, side, depth);
+        if (!isValidBuildingFootprint(vertices)) continue;
+        if (!meetsMinimumFootprintSize(vertices, options.settings)) continue;
+        if (!buildingFitsInsideBoundary(vertices, options.boundary.polygon)) continue;
+        if (hasForbiddenOverlap(vertices, options.forbiddenPolygons)) continue;
+        if (hasBuildingOverlap(vertices, edgeBlockingBuildings)) continue;
+        acceptedVertices = vertices;
+        break;
+      }
+
+      if (!acceptedVertices) continue;
+
+      const averageZ = frontCurve.reduce((sum, point) => sum + (point.z ?? DEFAULTS.buildingBaseZ), 0) / frontCurve.length;
+      const heightRandom = createRandom(`${buildingSeed}:height`);
+      const building: BuildingPolygon = {
+        id: makeBuildingId(buildingSeed, options.usedIds),
+        vertices: acceptedVertices,
+        baseZ: averageZ,
+        height: Math.round(randomRange(heightRandom, options.settings.minHeight, options.settings.maxHeight)),
+        color: DEFAULTS.buildingColor,
+        material: DEFAULTS.buildingMaterial,
+      };
+      generated.push(building);
+    }
+  });
+
+  return generated;
+}
+
+function findEdgeBetween(edges: Edge[], sourceId: string, targetId: string) {
+  return edges.find((edge) => (
+    (edge.source === sourceId && edge.target === targetId) ||
+    (edge.source === targetId && edge.target === sourceId)
+  ));
+}
+
+function getFaceEdgeIds(face: string[], edges: Edge[]) {
+  const edgeIds: string[] = [];
+  for (let index = 0; index < face.length; index++) {
+    const edge = findEdgeBetween(edges, face[index], face[(index + 1) % face.length]);
+    if (!edge) return [];
+    edgeIds.push(edge.id);
+  }
+  return edgeIds;
+}
+
+function getSelectedTargetEdges(edges: Edge[], selectedNodes: string[], selectedEdges: string[]) {
+  const selectedNodeSet = new Set(selectedNodes);
+  const selectedEdgeIds = new Set(selectedEdges);
+
+  edges.forEach((edge) => {
+    if (edge.target && selectedNodeSet.has(edge.source) && selectedNodeSet.has(edge.target)) {
+      selectedEdgeIds.add(edge.id);
+    }
+  });
+
+  return edges.filter((edge) => selectedEdgeIds.has(edge.id));
+}
+
+function getClosedFaces(nodes: Node[], edges: Edge[], selectedNodes: string[], selectedEdges: string[]) {
+  const selectedNodeSet = new Set(selectedNodes);
+  const selectedEdgeSet = new Set(selectedEdges);
+  const faces = findClosedAreas(nodes, edges);
+
+  return faces.filter((face) => {
+    const edgeIds = getFaceEdgeIds(face, edges);
+    if (edgeIds.length !== face.length) return false;
+
+    if (selectedEdgeSet.size > 0 && edgeIds.every((edgeId) => selectedEdgeSet.has(edgeId))) {
+      return true;
+    }
+
+    return (
+      selectedEdgeSet.size === 0 &&
+      selectedNodeSet.size === face.length &&
+      face.every((nodeId) => selectedNodeSet.has(nodeId))
+    );
+  });
+}
+
+function getRoadPolygonMap(mesh: MeshData) {
+  return new Map(mesh.roadPolygons.map((roadPolygon) => [roadPolygon.id, roadPolygon]));
+}
+
+function orientCurve(curve: Point[], edge: Edge, fromNodeId: string) {
+  return edge.source === fromNodeId ? [...curve] : [...curve].reverse();
+}
+
+function getAverageDistanceToPoint(curve: Point[], point: Point) {
+  if (curve.length === 0) return Infinity;
+  const total = curve.reduce((sum, curvePoint) => (
+    sum + Math.hypot(curvePoint.x - point.x, curvePoint.y - point.y)
+  ), 0);
+  return total / curve.length;
+}
+
+function getInsidePointCount(curve: Point[], boundary: FillBoundary) {
+  return curve.reduce((count, point) => count + (pointInPolygon(point, boundary.polygon) ? 1 : 0), 0);
+}
+
+function chooseInteriorCurve(roadPolygon: RoadPolygon, boundary: FillBoundary) {
+  const leftInside = getInsidePointCount(roadPolygon.outerLeftCurve, boundary);
+  const rightInside = getInsidePointCount(roadPolygon.outerRightCurve, boundary);
+  if (leftInside !== rightInside) {
+    return leftInside > rightInside
+      ? { curve: roadPolygon.outerLeftCurve, side: 'left' as CurveSide }
+      : { curve: roadPolygon.outerRightCurve, side: 'right' as CurveSide };
+  }
+
+  const leftDistance = getAverageDistanceToPoint(roadPolygon.outerLeftCurve, boundary.centroid);
+  const rightDistance = getAverageDistanceToPoint(roadPolygon.outerRightCurve, boundary.centroid);
+  return leftDistance <= rightDistance
+    ? { curve: roadPolygon.outerLeftCurve, side: 'left' as CurveSide }
+    : { curve: roadPolygon.outerRightCurve, side: 'right' as CurveSide };
+}
+
+function getFaceBoundary(face: string[], nodeById: Map<string, Node>): FillBoundary | null {
+  const polygon = face
+    .map((nodeId) => nodeById.get(nodeId)?.point)
+    .filter((point): point is Point => !!point);
+
+  if (polygon.length < 3) return null;
+  return {
+    polygon,
+    centroid: polygonCentroid(polygon),
+  };
+}
+
+function polygonSignedArea(polygon: Point[]) {
+  let signedArea = 0;
+  for (let index = 0; index < polygon.length; index++) {
+    const current = polygon[index];
+    const next = polygon[(index + 1) % polygon.length];
+    signedArea += current.x * next.y - next.x * current.y;
+  }
+  return signedArea;
+}
+
+function cleanBoundaryPoints(points: Point[]) {
+  const cleaned: Point[] = [];
+  for (const point of points) {
+    if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) continue;
+    const previous = cleaned[cleaned.length - 1];
+    if (previous && pointDistance(previous, point) <= BOUNDARY_EPSILON) continue;
+    cleaned.push(point);
+  }
+
+  if (cleaned.length > 2 && pointDistance(cleaned[0], cleaned[cleaned.length - 1]) <= BOUNDARY_EPSILON) {
+    cleaned.pop();
+  }
+
+  return cleaned;
+}
+
+function findInteriorPoint(polygon: Point[]) {
+  const centroid = polygonCentroid(polygon);
+  if (pointInPolygon(centroid, polygon)) return centroid;
+
+  for (let index = 1; index < polygon.length - 1; index++) {
+    const candidate = averagePoint([polygon[0], polygon[index], polygon[index + 1]]);
+    if (pointInPolygon(candidate, polygon)) return candidate;
+  }
+
+  return averagePoint(polygon);
+}
+
+function buildClosedSidewalkBoundary(
+  face: string[],
+  nodeById: Map<string, Node>,
+  edges: Edge[],
+  roadPolygonById: Map<string, RoadPolygon>,
+  mesh: MeshData
+): FillBoundary | null {
+  const centerlineBoundary = getFaceBoundary(face, nodeById);
+  if (!centerlineBoundary) return null;
+
+  const isClockwise = polygonSignedArea(centerlineBoundary.polygon) > 0;
+  const segments: Point[][] = [];
+
+  for (let index = 0; index < face.length; index++) {
+    const fromNodeId = face[index];
+    const toNodeId = face[(index + 1) % face.length];
+    const edge = findEdgeBetween(edges, fromNodeId, toNodeId);
+    const roadPolygon = edge ? roadPolygonById.get(edge.id) : null;
+    if (!edge || !roadPolygon || roadPolygon.ignoreMeshing) return null;
+
+    const interior = chooseInteriorCurve(roadPolygon, centerlineBoundary);
+    segments.push(orientCurve(interior.curve, edge, fromNodeId));
+  }
+
+  const boundaryPoints: Point[] = [];
+  for (let index = 0; index < segments.length; index++) {
+    const curve = segments[index];
+    const nextCurve = segments[(index + 1) % segments.length];
+    boundaryPoints.push(...curve);
+
+    const endPoint = curve[curve.length - 1];
+    const startPoint = nextCurve[0];
+    const hubNodeId = face[(index + 1) % face.length];
+    const hub = mesh.hubs.find((item) => item.id === hubNodeId);
+
+    if (hub && hub.outerPolygon.length > 0) {
+      boundaryPoints.push(...buildHubBoundaryPath(
+        hub.outerPolygon,
+        endPoint,
+        startPoint,
+        isClockwise,
+        hub.corners.length === 1
+      ));
+    }
+  }
+
+  const polygon = cleanBoundaryPoints(boundaryPoints);
+  if (polygon.length < 3) return null;
+
+  return {
+    polygon,
+    centroid: findInteriorPoint(polygon),
+    edgeSegments: segments,
+  };
+}
+
+export function generateBuildingFill(params: BuildingFillParams): BuildingFillResult {
+  const settings = sanitizeBuildingFillSettings(params.settings);
+  const seedPrefix = params.seedSalt ? `fill:${params.seedSalt}` : 'fill:default';
+  const mesh = buildNetworkMesh(
+    params.nodes,
+    params.edges,
+    params.chamferAngle,
+    params.meshResolution,
+    params.laneWidth,
+    [],
+    []
+  );
+  const roadPolygonById = getRoadPolygonMap(mesh);
+  const forbiddenClosedFillPolygons = [
+    ...mesh.hubs.map((hub) => hub.outerPolygon),
+    ...mesh.roadPolygons.map((roadPolygon) => roadPolygon.outerPolygon),
+    ...mesh.crosswalks.map((crosswalk) => crosswalk.polygon),
+  ].filter((polygon) => polygon.length >= 3);
+  const nodeById = new Map(params.nodes.map((node) => [node.id, node]));
+  const usedIds = new Set(params.buildings.map((building) => building.id));
+  const selectedTargetEdges = getSelectedTargetEdges(params.edges, params.selectedNodes, params.selectedEdges);
+  const closedFaces = getClosedFaces(params.nodes, params.edges, params.selectedNodes, params.selectedEdges);
+  const generated: BuildingPolygon[] = [];
+
+  if (closedFaces.length > 0) {
+    closedFaces.forEach((face, faceIndex) => {
+      const boundary = buildClosedSidewalkBoundary(face, nodeById, params.edges, roadPolygonById, mesh);
+      if (!boundary) return;
+
+      const buildings = generateClosedBoundaryBuildings({
+        boundary,
+        settings,
+        existingBuildings: params.buildings,
+        forbiddenPolygons: forbiddenClosedFillPolygons,
+        usedIds,
+        seed: `${seedPrefix}:closed:${face.join('-')}:${faceIndex}`,
+      });
+      generated.push(...buildings);
+    });
+
+    return {
+      buildings: generated,
+      mode: generated.length > 0 ? 'closed' : 'none',
+    };
+  }
+
+  selectedTargetEdges.forEach((edge) => {
+    const roadPolygon = roadPolygonById.get(edge.id);
+    if (!roadPolygon || roadPolygon.ignoreMeshing) return;
+
+    const leftBuildings = generateBuildingsAlongCurve({
+      curve: roadPolygon.outerLeftCurve,
+      side: 'left',
+      settings,
+      existingBuildings: params.buildings,
+      forbiddenPolygons: forbiddenClosedFillPolygons,
+      usedIds,
+      seed: `${seedPrefix}:open:${edge.id}:left`,
+    });
+    generated.push(...leftBuildings);
+
+    const rightBuildings = generateBuildingsAlongCurve({
+      curve: roadPolygon.outerRightCurve,
+      side: 'right',
+      settings,
+      existingBuildings: params.buildings,
+      forbiddenPolygons: forbiddenClosedFillPolygons,
+      usedIds,
+      seed: `${seedPrefix}:open:${edge.id}:right`,
+    });
+    generated.push(...rightBuildings);
+  });
+
+  return {
+    buildings: generated,
+    mode: generated.length > 0 ? 'open' : 'none',
+  };
+}

--- a/tools/intersection-visualizer/src/lib/buildings.ts
+++ b/tools/intersection-visualizer/src/lib/buildings.ts
@@ -1,8 +1,23 @@
 import { DEFAULTS } from './constants';
 import { BuildingPolygon, Point } from './types';
 
-export function getBuildingBaseZ(building: Pick<BuildingPolygon, 'baseZ'>) {
-  return building.baseZ ?? DEFAULTS.buildingBaseZ;
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function getLowestPointZ(points: Point[] | undefined, fallback = DEFAULTS.buildingBaseZ) {
+  let lowest: number | undefined;
+  for (const point of points ?? []) {
+    const z = finiteNumber(point.z);
+    if (z === undefined) continue;
+    lowest = lowest === undefined ? z : Math.min(lowest, z);
+  }
+
+  return lowest ?? fallback;
+}
+
+export function getBuildingBaseZ(building: Pick<BuildingPolygon, 'baseZ'> & { vertices?: Point[] }) {
+  return getLowestPointZ(building.vertices, building.baseZ ?? DEFAULTS.buildingBaseZ);
 }
 
 export function getBuildingHeight(building: Pick<BuildingPolygon, 'height'>) {
@@ -59,9 +74,14 @@ export function cleanBuildingVertices(vertices: Point[]) {
   const cleaned: Point[] = [];
   for (const vertex of vertices) {
     if (!Number.isFinite(vertex.x) || !Number.isFinite(vertex.y)) continue;
+    const nextVertex: Point = { x: vertex.x, y: vertex.y };
+    if (typeof vertex.z === 'number' && Number.isFinite(vertex.z)) {
+      nextVertex.z = vertex.z;
+    }
+
     const previous = cleaned[cleaned.length - 1];
-    if (previous && Math.hypot(previous.x - vertex.x, previous.y - vertex.y) < 0.01) continue;
-    cleaned.push({ x: vertex.x, y: vertex.y });
+    if (previous && Math.hypot(previous.x - nextVertex.x, previous.y - nextVertex.y) < 0.01) continue;
+    cleaned.push(nextVertex);
   }
 
   if (cleaned.length > 2) {
@@ -74,4 +94,3 @@ export function cleanBuildingVertices(vertices: Point[]) {
 
   return cleaned;
 }
-

--- a/tools/intersection-visualizer/src/lib/buildings.ts
+++ b/tools/intersection-visualizer/src/lib/buildings.ts
@@ -1,0 +1,77 @@
+import { DEFAULTS } from './constants';
+import { BuildingPolygon, Point } from './types';
+
+export function getBuildingBaseZ(building: Pick<BuildingPolygon, 'baseZ'>) {
+  return building.baseZ ?? DEFAULTS.buildingBaseZ;
+}
+
+export function getBuildingHeight(building: Pick<BuildingPolygon, 'height'>) {
+  return Math.max(1, building.height || DEFAULTS.buildingHeight);
+}
+
+export function getBuildingCenter(building: Pick<BuildingPolygon, 'vertices'>): Point {
+  if (!building.vertices.length) return { x: 0, y: 0 };
+
+  let signedArea = 0;
+  let cx = 0;
+  let cy = 0;
+
+  for (let index = 0; index < building.vertices.length; index++) {
+    const current = building.vertices[index];
+    const next = building.vertices[(index + 1) % building.vertices.length];
+    const cross = current.x * next.y - next.x * current.y;
+    signedArea += cross;
+    cx += (current.x + next.x) * cross;
+    cy += (current.y + next.y) * cross;
+  }
+
+  if (Math.abs(signedArea) > 0.0001) {
+    const factor = 1 / (3 * signedArea);
+    return { x: cx * factor, y: cy * factor };
+  }
+
+  const sum = building.vertices.reduce((acc, vertex) => ({
+    x: acc.x + vertex.x,
+    y: acc.y + vertex.y,
+  }), { x: 0, y: 0 });
+  return { x: sum.x / building.vertices.length, y: sum.y / building.vertices.length };
+}
+
+export function pointInBuilding(point: Point, building: Pick<BuildingPolygon, 'vertices'>) {
+  const vertices = building.vertices;
+  if (vertices.length < 3) return false;
+
+  let inside = false;
+  for (let i = 0, j = vertices.length - 1; i < vertices.length; j = i++) {
+    const pi = vertices[i];
+    const pj = vertices[j];
+    if (
+      (pi.y > point.y) !== (pj.y > point.y) &&
+      point.x < ((pj.x - pi.x) * (point.y - pi.y)) / (pj.y - pi.y) + pi.x
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+export function cleanBuildingVertices(vertices: Point[]) {
+  const cleaned: Point[] = [];
+  for (const vertex of vertices) {
+    if (!Number.isFinite(vertex.x) || !Number.isFinite(vertex.y)) continue;
+    const previous = cleaned[cleaned.length - 1];
+    if (previous && Math.hypot(previous.x - vertex.x, previous.y - vertex.y) < 0.01) continue;
+    cleaned.push({ x: vertex.x, y: vertex.y });
+  }
+
+  if (cleaned.length > 2) {
+    const first = cleaned[0];
+    const last = cleaned[cleaned.length - 1];
+    if (Math.hypot(first.x - last.x, first.y - last.y) < 0.01) {
+      cleaned.pop();
+    }
+  }
+
+  return cleaned;
+}
+

--- a/tools/intersection-visualizer/src/lib/constants.ts
+++ b/tools/intersection-visualizer/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const COLORS = ['#ef4444', '#3b82f6', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899'];
 export const ROAD_NETWORK_SCHEMA = 'cab87-road-network';
-export const ROAD_NETWORK_VERSION = 1;
+export const ROAD_NETWORK_VERSION = 2;
 
 export const DEFAULTS = {
   roadWidth: 60,
@@ -10,6 +10,10 @@ export const DEFAULTS = {
   softSelectionRadius: 200,
   chamferAngle: 70,
   meshResolution: 20,
+  buildingBaseZ: 4,
+  buildingHeight: 80,
+  buildingColor: '#64748b',
+  buildingMaterial: 'Concrete',
 };
 
 export function sanitizeMeshResolution(value: unknown): number {

--- a/tools/intersection-visualizer/src/lib/constants.ts
+++ b/tools/intersection-visualizer/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { BuildingFillSettings } from './types';
+
 export const COLORS = ['#ef4444', '#3b82f6', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899'];
 export const ROAD_NETWORK_SCHEMA = 'cab87-road-network';
 export const ROAD_NETWORK_VERSION = 2;
@@ -14,10 +16,48 @@ export const DEFAULTS = {
   buildingHeight: 80,
   buildingColor: '#64748b',
   buildingMaterial: 'Concrete',
+  buildingFillMinWidth: 48,
+  buildingFillMaxWidth: 120,
+  buildingFillMinHeight: 50,
+  buildingFillMaxHeight: 160,
 };
 
 export function sanitizeMeshResolution(value: unknown): number {
   const parsed = typeof value === 'number' ? value : parseInt(String(value), 10);
   if (!Number.isFinite(parsed)) return DEFAULTS.meshResolution;
   return Math.max(5, Math.min(100, Math.round(parsed)));
+}
+
+function sanitizePositiveNumber(value: unknown, fallback: number): number {
+  const parsed = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.max(1, Math.round(parsed));
+}
+
+function sanitizeRange(minValue: unknown, maxValue: unknown, fallbackMin: number, fallbackMax: number) {
+  const min = sanitizePositiveNumber(minValue, fallbackMin);
+  const max = sanitizePositiveNumber(maxValue, fallbackMax);
+  return min <= max ? { min, max } : { min: max, max: min };
+}
+
+export function sanitizeBuildingFillSettings(value?: Partial<BuildingFillSettings> | null): BuildingFillSettings {
+  const width = sanitizeRange(
+    value?.minWidth,
+    value?.maxWidth,
+    DEFAULTS.buildingFillMinWidth,
+    DEFAULTS.buildingFillMaxWidth
+  );
+  const height = sanitizeRange(
+    value?.minHeight,
+    value?.maxHeight,
+    DEFAULTS.buildingFillMinHeight,
+    DEFAULTS.buildingFillMaxHeight
+  );
+
+  return {
+    minWidth: width.min,
+    maxWidth: width.max,
+    minHeight: height.min,
+    maxHeight: height.max,
+  };
 }

--- a/tools/intersection-visualizer/src/lib/meshExport.ts
+++ b/tools/intersection-visualizer/src/lib/meshExport.ts
@@ -22,6 +22,9 @@ type RobloxChunkLayer = {
   kind?: 'surface' | 'marking';
   includeCollision?: boolean;
   collisionBaseName?: string;
+  driveSurface?: boolean;
+  crashObstacle?: boolean;
+  buildingId?: string;
 };
 
 type Bounds = {
@@ -305,6 +308,22 @@ function getRobloxLayers(meshData: MeshData): RobloxChunkLayer[] {
     });
   });
 
+  meshData.buildingMeshes.forEach((building, index) => {
+    layers.push({
+      layer: `building_${index + 1}`,
+      baseName: `BuildingSurface_${index + 1}`,
+      collisionBaseName: `BuildingCollision_${index + 1}`,
+      surfaceType: 'building',
+      triangles: building.triangles,
+      color: building.color,
+      material: building.material || 'Concrete',
+      includeCollision: true,
+      driveSurface: false,
+      crashObstacle: true,
+      buildingId: building.id,
+    });
+  });
+
   return layers;
 }
 
@@ -333,6 +352,14 @@ export function createRoadMeshExportGroup(meshData: MeshData): THREE.Group {
     });
   });
 
+  meshData.buildingMeshes.forEach((building, index) => {
+    addLayer(group, {
+      name: building.name || `Building_${index + 1}`,
+      triangles: building.triangles,
+      color: building.color,
+    });
+  });
+
   group.updateMatrixWorld(true);
   return group;
 }
@@ -352,6 +379,7 @@ export function createRobloxRoadMeshExport(meshData: MeshData) {
     const isCollision = kind === 'collision';
     const name = chunkName(isCollision ? (layer.collisionBaseName ?? `${layer.baseName}Collision`) : layer.baseName, bucket, batchIndex);
     const yOffset = layer.yOffset ?? 0;
+    const isDriveSurface = isCollision && (layer.driveSurface ?? true);
     const geometry = isCollision
       ? createCollisionGeometry(batch, yOffset, ROBLOX_COLLISION_THICKNESS, 0)
       : createTriangleGeometry(batch, yOffset, 0);
@@ -371,10 +399,12 @@ export function createRobloxRoadMeshExport(meshData: MeshData) {
       canQuery: isCollision,
       canTouch: false,
       castShadow: false,
-      driveSurface: isCollision,
+      driveSurface: isDriveSurface,
+      crashObstacle: isCollision && layer.crashObstacle === true,
       collisionFidelity: isCollision ? 'PreciseConvexDecomposition' : 'Box',
       triangleCount: actualTriangleCount,
       inputTriangleCount: batch.length,
+      buildingId: layer.buildingId,
       chunkKey: bucket.chunkY === undefined
         ? `${bucket.chunkX}:${bucket.chunkZ}`
         : `${bucket.chunkX}:${bucket.chunkY}:${bucket.chunkZ}`,

--- a/tools/intersection-visualizer/src/lib/meshing.ts
+++ b/tools/intersection-visualizer/src/lib/meshing.ts
@@ -1,6 +1,6 @@
 import { DEFAULTS } from './constants';
 import { Point, Node, Edge, PolygonFill, MeshData, Triangle, BuildingPolygon } from "./types";
-import { cleanBuildingVertices } from './buildings';
+import { cleanBuildingVertices, getBuildingBaseZ } from './buildings';
 import { getDir, intersectSegmentPolygon, segmentIntersect } from "./math";
 import { calculateBothCornerPoints } from "./junctions";
 import { getEdgeControlPoints, sampleEdgeSpline, hasCrosswalk, isTrueJunction, getIncidentConnections } from "./network";
@@ -1096,7 +1096,7 @@ function buildBuildingMeshes(buildings: BuildingPolygon[]): MeshData['buildingMe
     const vertices = cleanBuildingVertices(building.vertices || []);
     if (vertices.length < 3) continue;
 
-    const baseZ = building.baseZ ?? DEFAULTS.buildingBaseZ;
+    const baseZ = getBuildingBaseZ(building);
     const height = Math.max(1, building.height || DEFAULTS.buildingHeight);
     const topZ = baseZ + height;
     const baseBoundary = vertices.map((vertex) => ({ x: vertex.x, y: vertex.y, z: baseZ }));

--- a/tools/intersection-visualizer/src/lib/meshing.ts
+++ b/tools/intersection-visualizer/src/lib/meshing.ts
@@ -1,5 +1,6 @@
 import { DEFAULTS } from './constants';
-import { Point, Node, Edge, PolygonFill, MeshData, Triangle } from "./types";
+import { Point, Node, Edge, PolygonFill, MeshData, Triangle, BuildingPolygon } from "./types";
+import { cleanBuildingVertices } from './buildings';
 import { getDir, intersectSegmentPolygon, segmentIntersect } from "./math";
 import { calculateBothCornerPoints } from "./junctions";
 import { getEdgeControlPoints, sampleEdgeSpline, hasCrosswalk, isTrueJunction, getIncidentConnections } from "./network";
@@ -262,7 +263,15 @@ function buildIgnoredRoadPolygon(edge: Edge, centerLine: Point[], hubs: MeshData
   };
 }
 
-export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: number, meshResolution: number = DEFAULTS.meshResolution, laneWidth: number = DEFAULTS.laneWidth, polygonFills: PolygonFill[] = []): MeshData {
+export function buildNetworkMesh(
+  nodes: Node[],
+  edges: Edge[],
+  chamferAngleDeg: number,
+  meshResolution: number = DEFAULTS.meshResolution,
+  laneWidth: number = DEFAULTS.laneWidth,
+  polygonFills: PolygonFill[] = [],
+  buildings: BuildingPolygon[] = []
+): MeshData {
   const mesh: MeshData = {
     vertices: [],
     triangles: [],
@@ -279,7 +288,9 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
     dashedLineTriangles: [],
     solidLineTriangles: [],
     laneArrows: [],
-    polygonTriangles: []
+    polygonTriangles: [],
+    buildingMeshes: [],
+    buildingTriangles: []
   };
 
   const nodeClearances = new Map<string, Map<string, number>>();
@@ -1069,7 +1080,60 @@ export function buildNetworkMesh(nodes: Node[], edges: Edge[], chamferAngleDeg: 
     mesh.polygonTriangles.push({ triangles: fillTriangles, color: poly.color });
   }
 
+  const buildingMeshes = buildBuildingMeshes(buildings);
+  mesh.buildingMeshes.push(...buildingMeshes);
+  buildingMeshes.forEach((buildingMesh) => {
+    mesh.buildingTriangles.push(...buildingMesh.triangles);
+  });
+
   return mesh;
+}
+
+function buildBuildingMeshes(buildings: BuildingPolygon[]): MeshData['buildingMeshes'] {
+  const meshes: MeshData['buildingMeshes'] = [];
+
+  for (const building of buildings) {
+    const vertices = cleanBuildingVertices(building.vertices || []);
+    if (vertices.length < 3) continue;
+
+    const baseZ = building.baseZ ?? DEFAULTS.buildingBaseZ;
+    const height = Math.max(1, building.height || DEFAULTS.buildingHeight);
+    const topZ = baseZ + height;
+    const baseBoundary = vertices.map((vertex) => ({ x: vertex.x, y: vertex.y, z: baseZ }));
+    const topBoundary = vertices.map((vertex) => ({ x: vertex.x, y: vertex.y, z: topZ }));
+
+    const topTriangles = buildGridMesh(topBoundary);
+    const bottomTriangles = buildGridMesh(baseBoundary).map((triangle): Triangle => [triangle[0], triangle[2], triangle[1]]);
+    const wallTriangles: Triangle[] = [];
+
+    for (let index = 0; index < vertices.length; index++) {
+      const nextIndex = (index + 1) % vertices.length;
+      const baseA = baseBoundary[index];
+      const baseB = baseBoundary[nextIndex];
+      const topB = topBoundary[nextIndex];
+      const topA = topBoundary[index];
+      wallTriangles.push([baseA, baseB, topB], [baseA, topB, topA]);
+    }
+
+    const triangles = [...topTriangles, ...bottomTriangles, ...wallTriangles];
+    if (triangles.length === 0) continue;
+
+    meshes.push({
+      id: building.id,
+      name: building.name,
+      vertices: baseBoundary,
+      baseZ,
+      height,
+      color: building.color || DEFAULTS.buildingColor,
+      material: building.material || DEFAULTS.buildingMaterial,
+      triangles,
+      topTriangles,
+      bottomTriangles,
+      wallTriangles,
+    });
+  }
+
+  return meshes;
 }
 
 function buildGridMesh(boundaryPoints: Point[]): Triangle[] {

--- a/tools/intersection-visualizer/src/lib/render2d.ts
+++ b/tools/intersection-visualizer/src/lib/render2d.ts
@@ -1,6 +1,7 @@
-import { Point, Node, Edge } from './types';
+import { Point, Node, Edge, BuildingPolygon } from './types';
 import { getExtendedEdgeControlPoints } from './network';
 import { buildNetworkMesh } from './meshing';
+import { getBuildingBaseZ, getBuildingCenter, getBuildingHeight } from './buildings';
 
 export const drawNetwork2D = (
   ctx: CanvasRenderingContext2D,
@@ -18,6 +19,10 @@ export const drawNetwork2D = (
   meshResolution: number,
   laneWidth: number,
   polygonFills: any[],
+  buildings: BuildingPolygon[],
+  selectedBuildingId: string | null,
+  selectedBuildingVertex: { buildingId: string; vertexIndex: number } | null,
+  buildingDraft: Point[],
   softSelectionEnabled: boolean,
   softSelectionRadius: number,
   draggingPoint: Point | null,
@@ -76,9 +81,9 @@ export const drawNetwork2D = (
     ctx.stroke();
   }
 
-  if (nodes.length === 0) return;
+  if (nodes.length === 0 && buildings.length === 0 && buildingDraft.length === 0) return;
 
-  const mesh = buildNetworkMesh(nodes, edges, chamferAngle, meshResolution, laneWidth, polygonFills);
+  const mesh = buildNetworkMesh(nodes, edges, chamferAngle, meshResolution, laneWidth, polygonFills, buildings);
 
   if (showMesh) {
     mesh.triangles.forEach((tri, idx) => {
@@ -109,6 +114,23 @@ export const drawNetwork2D = (
       ctx.fill();
       ctx.strokeStyle = pg.color;
       ctx.lineWidth = 1;
+      ctx.stroke();
+    });
+  }
+
+  if (showMesh && mesh.buildingMeshes) {
+    mesh.buildingMeshes.forEach(building => {
+      ctx.beginPath();
+      building.triangles.forEach(tri => {
+        ctx.moveTo(tri[0].x, tri[0].y);
+        ctx.lineTo(tri[1].x, tri[1].y);
+        ctx.lineTo(tri[2].x, tri[2].y);
+        ctx.lineTo(tri[0].x, tri[0].y);
+      });
+      ctx.fillStyle = building.color + '44';
+      ctx.strokeStyle = building.color;
+      ctx.lineWidth = 1;
+      ctx.fill();
       ctx.stroke();
     });
   }
@@ -472,6 +494,79 @@ export const drawNetwork2D = (
         r.draw();
     });
 
+  }
+
+  buildings.forEach((building) => {
+    if (building.vertices.length < 2) return;
+    const isSelected = selectedBuildingId === building.id;
+    const center = getBuildingCenter(building);
+    const baseZ = getBuildingBaseZ(building);
+    const height = getBuildingHeight(building);
+
+    ctx.save();
+    ctx.shadowColor = 'transparent';
+    ctx.beginPath();
+    ctx.moveTo(building.vertices[0].x, building.vertices[0].y);
+    building.vertices.slice(1).forEach((vertex) => ctx.lineTo(vertex.x, vertex.y));
+    ctx.closePath();
+    ctx.fillStyle = (building.color || '#64748b') + (isSelected ? '77' : '44');
+    ctx.strokeStyle = isSelected ? '#f97316' : building.color || '#64748b';
+    ctx.lineWidth = isSelected ? 3 : 1.5;
+    ctx.fill();
+    ctx.stroke();
+
+    building.vertices.forEach((vertex, vertexIndex) => {
+      const isVertexSelected = selectedBuildingVertex?.buildingId === building.id && selectedBuildingVertex.vertexIndex === vertexIndex;
+      ctx.beginPath();
+      ctx.rect(vertex.x - 7, vertex.y - 7, 14, 14);
+      ctx.fillStyle = isVertexSelected ? '#ffffff' : isSelected ? '#fdba74' : '#fb923c';
+      ctx.strokeStyle = '#111827';
+      ctx.lineWidth = 2;
+      ctx.fill();
+      ctx.stroke();
+    });
+
+    ctx.beginPath();
+    ctx.arc(center.x, center.y, isSelected && !selectedBuildingVertex ? 9 : 7, 0, Math.PI * 2);
+    ctx.fillStyle = isSelected && !selectedBuildingVertex ? '#ffffff' : '#f97316';
+    ctx.strokeStyle = '#111827';
+    ctx.lineWidth = 2;
+    ctx.fill();
+    ctx.stroke();
+
+    if (isSelected) {
+      ctx.fillStyle = '#f8fafc';
+      ctx.font = '12px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText(`${Math.round(height)}h @ ${Math.round(baseZ)}`, center.x, center.y - 14);
+    }
+    ctx.restore();
+  });
+
+  if (buildingDraft.length > 0) {
+    ctx.save();
+    ctx.shadowColor = 'transparent';
+    ctx.strokeStyle = '#f97316';
+    ctx.fillStyle = 'rgba(249, 115, 22, 0.18)';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([8, 6]);
+    ctx.beginPath();
+    ctx.moveTo(buildingDraft[0].x, buildingDraft[0].y);
+    buildingDraft.slice(1).forEach((vertex) => ctx.lineTo(vertex.x, vertex.y));
+    if (buildingDraft.length >= 3) ctx.closePath();
+    ctx.stroke();
+    if (buildingDraft.length >= 3) ctx.fill();
+    ctx.setLineDash([]);
+    buildingDraft.forEach((vertex, index) => {
+      ctx.beginPath();
+      ctx.arc(vertex.x, vertex.y, index === 0 ? 8 : 6, 0, Math.PI * 2);
+      ctx.fillStyle = index === 0 ? '#ffffff' : '#f97316';
+      ctx.strokeStyle = '#111827';
+      ctx.lineWidth = 2;
+      ctx.fill();
+      ctx.stroke();
+    });
+    ctx.restore();
   }
 
   // Soft selection radius

--- a/tools/intersection-visualizer/src/lib/render2d.ts
+++ b/tools/intersection-visualizer/src/lib/render2d.ts
@@ -1,4 +1,4 @@
-import { Point, Node, Edge, BuildingPolygon } from './types';
+import { Point, Node, Edge, BuildingPolygon, VisibilitySettings } from './types';
 import { getExtendedEdgeControlPoints } from './network';
 import { buildNetworkMesh } from './meshing';
 import { getBuildingBaseZ, getBuildingCenter, getBuildingHeight } from './buildings';
@@ -12,7 +12,7 @@ export const drawNetwork2D = (
   selectedNodes: string[],
   selectedNode: string | null,
   showMesh: boolean,
-  showControlPoints: boolean,
+  visibilitySettings: VisibilitySettings,
   isConnectMode: boolean,
   isMergeMode: boolean,
   chamferAngle: number,
@@ -203,7 +203,7 @@ export const drawNetwork2D = (
                 }
             });
 
-            if (count > 0 && fillDef) {
+            if (visibilitySettings.showPolyFillHandles && count > 0 && fillDef) {
                 renderables.push({
                     z: 9999,
                     priority: 100, // On top of everything
@@ -515,26 +515,30 @@ export const drawNetwork2D = (
     ctx.fill();
     ctx.stroke();
 
-    building.vertices.forEach((vertex, vertexIndex) => {
-      const isVertexSelected = selectedBuildingVertex?.buildingId === building.id && selectedBuildingVertex.vertexIndex === vertexIndex;
+    if (visibilitySettings.showBuildingControlPoints) {
+      building.vertices.forEach((vertex, vertexIndex) => {
+        const isVertexSelected = selectedBuildingVertex?.buildingId === building.id && selectedBuildingVertex.vertexIndex === vertexIndex;
+        ctx.beginPath();
+        ctx.rect(vertex.x - 7, vertex.y - 7, 14, 14);
+        ctx.fillStyle = isVertexSelected ? '#ffffff' : isSelected ? '#fdba74' : '#fb923c';
+        ctx.strokeStyle = '#111827';
+        ctx.lineWidth = 2;
+        ctx.fill();
+        ctx.stroke();
+      });
+    }
+
+    if (visibilitySettings.showBuildingHandles) {
       ctx.beginPath();
-      ctx.rect(vertex.x - 7, vertex.y - 7, 14, 14);
-      ctx.fillStyle = isVertexSelected ? '#ffffff' : isSelected ? '#fdba74' : '#fb923c';
+      ctx.arc(center.x, center.y, isSelected && !selectedBuildingVertex ? 9 : 7, 0, Math.PI * 2);
+      ctx.fillStyle = isSelected && !selectedBuildingVertex ? '#ffffff' : '#f97316';
       ctx.strokeStyle = '#111827';
       ctx.lineWidth = 2;
       ctx.fill();
       ctx.stroke();
-    });
+    }
 
-    ctx.beginPath();
-    ctx.arc(center.x, center.y, isSelected && !selectedBuildingVertex ? 9 : 7, 0, Math.PI * 2);
-    ctx.fillStyle = isSelected && !selectedBuildingVertex ? '#ffffff' : '#f97316';
-    ctx.strokeStyle = '#111827';
-    ctx.lineWidth = 2;
-    ctx.fill();
-    ctx.stroke();
-
-    if (isSelected) {
+    if (isSelected && visibilitySettings.showBuildingHandles) {
       ctx.fillStyle = '#f8fafc';
       ctx.font = '12px sans-serif';
       ctx.textAlign = 'center';
@@ -581,7 +585,7 @@ export const drawNetwork2D = (
   }
 
   // Nodes and control points
-  nodes.forEach(n => {
+  if (visibilitySettings.showNodeHandles) nodes.forEach(n => {
       const isActive = selectedNode === n.id;
       const isSelected = selectedNodes.includes(n.id) || isActive;
 
@@ -609,7 +613,7 @@ export const drawNetwork2D = (
   });
 
   edges.forEach((e) => {
-      if (showControlPoints) {
+      if (visibilitySettings.showNodeControlPoints) {
           const controlPts = getExtendedEdgeControlPoints(e, nodes, edges, chamferAngle);
           if (controlPts.length > 0) {
               const cubicPts = controlPts;
@@ -638,7 +642,7 @@ export const drawNetwork2D = (
 
       e.points.forEach((pt, j) => {
           const isAnchor = (j % 3 === 2);
-          if (!showControlPoints && !isAnchor) return;
+          if (!visibilitySettings.showNodeControlPoints) return;
 
           ctx.beginPath();
           const isSelectedPoint = selectedPoints?.some(p => p.edgeId === e.id && p.pointIndex === j) || false;

--- a/tools/intersection-visualizer/src/lib/types.ts
+++ b/tools/intersection-visualizer/src/lib/types.ts
@@ -35,6 +35,30 @@ export type BuildingPolygon = {
   height: number;
   color: string;
   material?: string;
+  fillSource?: BuildingFillSource;
+};
+
+export type BuildingFillSettings = {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+  maxHeight: number;
+};
+
+export type BuildingFillSource = {
+  groupId: string;
+  mode: 'open' | 'closed';
+  selectedNodes: string[];
+  selectedEdges: string[];
+  settings: BuildingFillSettings;
+};
+
+export type VisibilitySettings = {
+  showNodeHandles: boolean;
+  showNodeControlPoints: boolean;
+  showPolyFillHandles: boolean;
+  showBuildingHandles: boolean;
+  showBuildingControlPoints: boolean;
 };
 
 export type Edge = {

--- a/tools/intersection-visualizer/src/lib/types.ts
+++ b/tools/intersection-visualizer/src/lib/types.ts
@@ -27,6 +27,16 @@ export type PolygonFill = {
   color: string;
 };
 
+export type BuildingPolygon = {
+  id: string;
+  name?: string;
+  vertices: Point[];
+  baseZ?: number;
+  height: number;
+  color: string;
+  material?: string;
+};
+
 export type Edge = {
   id: string;
   source: string; // Node ID
@@ -60,4 +70,18 @@ export type MeshData = {
   solidLineTriangles: Triangle[];
   laneArrows: { position: Point; dir: Point; ignoreMeshing?: boolean }[];
   polygonTriangles: { triangles: Triangle[], color: string }[];
+  buildingMeshes: {
+    id: string;
+    name?: string;
+    vertices: Point[];
+    baseZ: number;
+    height: number;
+    color: string;
+    material?: string;
+    triangles: Triangle[];
+    topTriangles: Triangle[];
+    bottomTriangles: Triangle[];
+    wallTriangles: Triangle[];
+  }[];
+  buildingTriangles: Triangle[];
 };


### PR DESCRIPTION
## Summary

- Add authored/extruded building polygon support through the road graph data, meshing/export path, runtime loading, and Studio plugin workflow.
- Add intersection visualizer tools for editing building footprints, linked building-fill generation from selected roads or polygon fills, and handle visibility controls.
- Document the updated Road Maker sync expectations and visualizer export schema.

## Impact

This lets authored road networks carry building footprint data alongside roads, then render/export/load those buildings consistently in the prototype and tooling. Generated fill footprints remain linked to their source road selection until edited manually.

## Validation

- `npm run lint` in `tools/intersection-visualizer`
- `npm run build` in `tools/intersection-visualizer` (passes with Vite large-chunk warning)